### PR TITLE
An attempt at fixing the crashes I found

### DIFF
--- a/lib/rails_erd/diagram.rb
+++ b/lib/rails_erd/diagram.rb
@@ -153,6 +153,14 @@ module RailsERD
       }.compact.tap do |entities|
         raise "No entities found; create your models first!" if entities.empty?
       end
+      @domain.entities.reject do |entity|
+        if entity.model.table_exists?
+          false
+        else
+          warn "Ignoring model #{entity.model} - table not present"
+          true
+        end
+      end
     end
     
     def filtered_relationships
@@ -160,6 +168,14 @@ module RailsERD
         !options.inheritance && (relationship.source.specialized? || relationship.destination.specialized?) or
         !options.indirect && relationship.indirect?
       }
+      @domain.relationships.reject do |relationship|
+        if relationship.source.model.table_exists? and relationship.destination.model.table_exists?
+          false
+        else
+          warn "Ignoring relationship between #{relationship.source.model} and #{relationship.destination.model} - table not present"
+          true
+        end
+      end
     end
     
     def filtered_specializations


### PR DESCRIPTION
The code I am submitting is so horrible compared with your elegant code that I hesitate to put it in the public domain, but I am a beginner so...

Changed the filtered_entities and filtered_relationships methods in Diagram to print a warning and skip the model when no table exists.  I suspect I should have done something with specialization as well but I didn't know what it was.  An alternative would be to print an empty entity with "Table Not Found".
