### PR TITLE
fix for relationships that are missing either source or destination

### DIFF
--- a/lib/rails_erd/domain.rb
+++ b/lib/rails_erd/domain.rb
@@ -59,7 +59,7 @@ module RailsERD
 
     # Returns all relationships in your domain model.
     def relationships
-      @relationships ||= Relationship.from_associations(self, associations)
+      @relationships ||= Relationship.from_associations(self, associations).select {|r| r.source && r.destination}
     end
 
     # Returns all specializations in your domain model.


### PR DESCRIPTION
rails-erd was breaking on our rails 3.2 app because a relationship returned by Relationship.from_associations was missing a destination (not sure why exactly that was)
