### PR TITLE
'only' and 'exclude' options for filtering models

### DIFF
--- a/lib/rails_erd.rb
+++ b/lib/rails_erd.rb
@@ -59,6 +59,8 @@ module RailsERD
     :orientation, :horizontal,
     :polymorphism, false,
     :warn, true,
-    :title, true
+    :title, true,
+    :exclude, nil,
+    :only, nil
   ]
 end

--- a/lib/rails_erd/diagram.rb
+++ b/lib/rails_erd/diagram.rb
@@ -3,7 +3,7 @@ require "rails_erd/domain"
 module RailsERD
   # This class is an abstract class that will process a domain model and
   # allows easy creation of diagrams. To implement a new diagram type, derive
-  # from this class and override +process_entity+, +process_relationship+, 
+  # from this class and override +process_entity+, +process_relationship+,
   # and (optionally) +save+.
   #
   # As an example, a diagram class that generates code that can be used with
@@ -73,13 +73,13 @@ module RailsERD
       def create(options = {})
         new(Domain.generate(options), options).create
       end
-      
+
       protected
-      
+
       def setup(&block)
         callbacks[:setup] = block
       end
-      
+
       def each_entity(&block)
         callbacks[:each_entity] = block
       end
@@ -91,7 +91,7 @@ module RailsERD
       def each_specialization(&block)
         callbacks[:each_specialization] = block
       end
-      
+
       def save(&block)
         callbacks[:save] = block
       end
@@ -105,7 +105,7 @@ module RailsERD
 
     # The options that are used to create this diagram.
     attr_reader :options
-    
+
     # The domain that this diagram represents.
     attr_reader :domain
 
@@ -113,13 +113,13 @@ module RailsERD
     def initialize(domain, options = {})
       @domain, @options = domain, RailsERD.options.merge(options)
     end
-    
+
     # Generates and saves the diagram, returning the result of +save+.
     def create
       generate
       save
     end
-    
+
     # Generates the diagram, but does not save the output. It is called
     # internally by Diagram#create.
     def generate
@@ -137,19 +137,21 @@ module RailsERD
         instance_exec relationship, &callbacks[:each_relationship]
       end
     end
-    
+
     def save
       instance_eval &callbacks[:save]
     end
-    
+
     private
-    
+
     def callbacks
       @callbacks ||= self.class.send(:callbacks)
     end
-    
+
     def filtered_entities
       @domain.entities.reject { |entity|
+        options.exclude && entity.model && [options.exclude].flatten.include?(entity.name.to_sym) or
+        options.only && entity.model && ![options.only].flatten.include?(entity.name.to_sym) or
         !options.inheritance && entity.specialized? or
         !options.polymorphism && entity.generalized? or
         !options.disconnected && entity.disconnected?
@@ -157,20 +159,20 @@ module RailsERD
         raise "No entities found; create your models first!" if entities.empty?
       end
     end
-    
+
     def filtered_relationships
       @domain.relationships.reject { |relationship|
         !options.indirect && relationship.indirect?
       }
     end
-    
+
     def filtered_specializations
       @domain.specializations.reject { |specialization|
         !options.inheritance && specialization.inheritance? or
         !options.polymorphism && specialization.polymorphic?
       }
     end
-    
+
     def filtered_attributes(entity)
       entity.attributes.reject { |attribute|
         # Select attributes that satisfy the conditions in the :attributes option.
@@ -178,7 +180,7 @@ module RailsERD
         [*options.attributes].none? { |type| attribute.send(:"#{type.to_s.chomp('s')}?") }
       }
     end
-    
+
     def warn(message)
       puts "Warning: #{message}" if options.warn
     end

--- a/test/unit/diagram_test.rb
+++ b/test/unit/diagram_test.rb
@@ -4,11 +4,11 @@ class DiagramTest < ActiveSupport::TestCase
   def setup
     load "rails_erd/diagram.rb"
   end
-  
+
   def teardown
     RailsERD.send :remove_const, :Diagram
   end
-  
+
   def retrieve_entities(options = {})
     klass = Class.new(Diagram)
     [].tap do |entities|
@@ -20,7 +20,7 @@ class DiagramTest < ActiveSupport::TestCase
       klass.create(options)
     end
   end
-  
+
   def retrieve_relationships(options = {})
     klass = Class.new(Diagram)
     [].tap do |relationships|
@@ -32,7 +32,7 @@ class DiagramTest < ActiveSupport::TestCase
       klass.create(options)
     end
   end
-  
+
   def retrieve_specializations(options = {})
     klass = Class.new(Diagram)
     [].tap do |specializations|
@@ -56,13 +56,13 @@ class DiagramTest < ActiveSupport::TestCase
       klass.create(options)
     end
   end
-  
+
   # Diagram ==================================================================
   test "domain sould return given domain" do
     domain = Object.new
     assert_same domain, Class.new(Diagram).new(domain).domain
   end
-  
+
   # Diagram DSL ==============================================================
   test "create should succeed silently if called on abstract class" do
     create_simple_domain
@@ -70,33 +70,33 @@ class DiagramTest < ActiveSupport::TestCase
       Diagram.create
     end
   end
-  
+
   test "create should succeed if called on subclass" do
     create_simple_domain
     assert_nothing_raised do
       Class.new(Diagram).create
     end
   end
-  
+
   test "create should call callbacks in instance in specific order" do
     create_simple_domain
     executed_calls = Class.new(Diagram) do
       setup do
         calls << :setup
       end
-      
+
       each_entity do
         calls << :entity
       end
-      
+
       each_relationship do
         calls << :relationship
       end
-      
+
       save do
         calls << :save
       end
-      
+
       def calls
         @calls ||= []
       end
@@ -123,13 +123,39 @@ class DiagramTest < ActiveSupport::TestCase
     end.new(Domain.generate)
     assert_equal "foobar", diagram.create
   end
-  
+
   # Entity filtering =========================================================
   test "generate should yield entities" do
     create_model "Foo"
     assert_equal [Foo], retrieve_entities.map(&:model)
   end
-  
+
+  test "generate should filter excluded entity" do
+    create_model "Book"
+    create_model "Author"
+    assert_equal [Book], retrieve_entities(:exclude => :Author).map(&:model)
+  end
+
+  test "generate should filter excluded entities" do
+    create_model "Book"
+    create_model "Author"
+    create_model "Editor"
+    assert_equal [Book], retrieve_entities(:exclude => [:Author, :Editor]).map(&:model)
+  end
+
+  test "generate should include only specified entity" do
+    create_model "Book"
+    create_model "Author"
+    assert_equal [Book], retrieve_entities(:only => [:Book]).map(&:model)
+  end
+
+  test "generate should include only specified entities" do
+    create_model "Book"
+    create_model "Author"
+    create_model "Editor"
+    assert_equal [Author, Editor], retrieve_entities(:only => [:Author, :Editor]).map(&:model)
+  end
+
   test "generate should filter disconnected entities if disconnected is false" do
     create_model "Book", :author => :references do
       belongs_to :author
@@ -138,24 +164,24 @@ class DiagramTest < ActiveSupport::TestCase
     create_model "Table", :type => :string
     assert_equal [Author, Book], retrieve_entities(:disconnected => false).map(&:model)
   end
-  
+
   test "generate should yield disconnected entities if disconnected is true" do
     create_model "Foo", :type => :string
     assert_equal [Foo], retrieve_entities(:disconnected => true).map(&:model)
   end
-  
+
   test "generate should filter specialized entities" do
     create_model "Foo", :type => :string
     Object.const_set :SpecialFoo, Class.new(Foo)
     assert_equal [Foo], retrieve_entities.map(&:model)
   end
-  
+
   test "generate should yield specialized entities if inheritance is true" do
     create_model "Foo", :type => :string
     Object.const_set :SpecialFoo, Class.new(Foo)
     assert_equal [Foo, SpecialFoo], retrieve_entities(:inheritance => true).map(&:model)
   end
-  
+
   test "generate should yield specialized entities with distinct tables" do
     create_model "Foo"
     Object.const_set :SpecialFoo, Class.new(Foo)
@@ -165,7 +191,7 @@ class DiagramTest < ActiveSupport::TestCase
     create_table "special_foo", {}, true
     assert_equal [Foo, SpecialFoo], retrieve_entities.map(&:model)
   end
-  
+
   test "generate should filter generalized entities" do
     create_model "Cannon"
     create_model "Galleon" do
@@ -173,7 +199,7 @@ class DiagramTest < ActiveSupport::TestCase
     end
     assert_equal ["Cannon", "Galleon"], retrieve_entities.map(&:name)
   end
-  
+
   test "generate should yield generalized entities if polymorphism is true" do
     create_model "Cannon"
     create_model "Galleon" do
@@ -181,13 +207,13 @@ class DiagramTest < ActiveSupport::TestCase
     end
     assert_equal ["Cannon", "Defensible", "Galleon"], retrieve_entities(:polymorphism => true).map(&:name)
   end
-  
+
   # Relationship filtering ===================================================
   test "generate should yield relationships" do
     create_simple_domain
     assert_equal 1, retrieve_relationships.length
   end
-  
+
   test "generate should yield indirect relationships if indirect is true" do
     create_model "Foo" do
       has_many :bazs
@@ -202,7 +228,7 @@ class DiagramTest < ActiveSupport::TestCase
     end
     assert_equal [false, false, true], retrieve_relationships(:indirect => true).map(&:indirect?)
   end
-  
+
   test "generate should filter indirect relationships if indirect is false" do
     create_model "Foo" do
       has_many :bazs
@@ -217,7 +243,7 @@ class DiagramTest < ActiveSupport::TestCase
     end
     assert_equal [false, false], retrieve_relationships(:indirect => false).map(&:indirect?)
   end
-  
+
   test "generate should yield relationships from specialized entities" do
     create_model "Foo", :bar => :references
     create_model "Bar", :type => :string
@@ -227,7 +253,7 @@ class DiagramTest < ActiveSupport::TestCase
     end
     assert_equal 1, retrieve_relationships.length
   end
-  
+
   test "generate should yield relationships to specialized entities" do
     create_model "Foo", :type => :string, :bar => :references
     Object.const_set :SpecialFoo, Class.new(Foo)
@@ -236,33 +262,33 @@ class DiagramTest < ActiveSupport::TestCase
     end
     assert_equal 1, retrieve_relationships.length
   end
-  
+
   # Specialization filtering =================================================
   test "generate should not yield specializations" do
     create_specialization
     create_generalization
     assert_equal [], retrieve_specializations
   end
-  
+
   test "generate should yield specializations but not generalizations if inheritance is true" do
     create_specialization
     create_generalization
     assert_equal ["Beer"], retrieve_specializations(:inheritance => true).map { |s| s.specialized.name }
   end
-  
+
   test "generate should yield generalizations but not specializations if polymorphism is true" do
     create_specialization
     create_generalization
     assert_equal ["Galleon"], retrieve_specializations(:polymorphism => true).map { |s| s.specialized.name }
   end
-  
+
   test "generate should yield specializations and generalizations if polymorphism and inheritance is true" do
     create_specialization
     create_generalization
     assert_equal ["Beer", "Galleon"], retrieve_specializations(:inheritance => true,
       :polymorphism => true).map { |s| s.specialized.name }
   end
-  
+
   # Attribute filtering ======================================================
   test "generate should yield content attributes by default" do
     create_model "Book", :title => :string, :created_at => :datetime, :author => :references do
@@ -271,7 +297,7 @@ class DiagramTest < ActiveSupport::TestCase
     create_model "Author"
     assert_equal %w{title}, retrieve_attribute_lists[Book].map(&:name)
   end
-  
+
   test "generate should yield primary key attributes if included" do
     create_model "Book", :title => :string
     create_model "Page", :book => :references do
@@ -279,7 +305,7 @@ class DiagramTest < ActiveSupport::TestCase
     end
     assert_equal %w{id}, retrieve_attribute_lists(:attributes => [:primary_keys])[Book].map(&:name)
   end
-  
+
   test "generate should yield foreign key attributes if included" do
     create_model "Book", :author => :references do
       belongs_to :author
@@ -287,7 +313,7 @@ class DiagramTest < ActiveSupport::TestCase
     create_model "Author"
     assert_equal %w{author_id}, retrieve_attribute_lists(:attributes => [:foreign_keys])[Book].map(&:name)
   end
-  
+
   test "generate should yield timestamp attributes if included" do
     create_model "Book", :created_at => :datetime, :created_on => :date, :updated_at => :datetime, :updated_on => :date
     create_model "Page", :book => :references do
@@ -296,7 +322,7 @@ class DiagramTest < ActiveSupport::TestCase
     assert_equal %w{created_at created_on updated_at updated_on},
       retrieve_attribute_lists(:attributes => [:timestamps])[Book].map(&:name)
   end
-  
+
   test "generate should yield combinations of attributes if included" do
     create_model "Book", :created_at => :datetime, :title => :string, :author => :references do
       belongs_to :author
@@ -305,7 +331,7 @@ class DiagramTest < ActiveSupport::TestCase
     assert_equal %w{created_at title},
       retrieve_attribute_lists(:attributes => [:content, :timestamps])[Book].map(&:name)
   end
-  
+
   test "generate should yield no attributes for specialized entities" do
     create_model "Beverage", :type => :string, :name => :string, :distillery => :string, :age => :integer
     Object.const_set :Whisky, Class.new(Beverage)


### PR DESCRIPTION
Ability to pass `only="Foo,Bar"` and `exclude=Foo,Bar` options as command line arguments in order to filter out models you wish on your diagram.
