### PR TITLE
add 'only' and 'exclude' options to CLI

### DIFF
--- a/lib/rails_erd/cli.rb
+++ b/lib/rails_erd/cli.rb
@@ -46,6 +46,16 @@ Choice.options do
     long "--connected"
     desc "Omit entities without relationships."
   end
+  
+  option :only do
+    long "--only"
+    desc "Filter to only include listed modeles in diagram."
+  end
+  
+  option :exclude do
+    long "--exclude"
+    desc "Filter to exclude listed modeles in diagram."
+  end
 
   separator ""
   separator "Output options:"


### PR DESCRIPTION
I saw a previous commit added 'only' and 'exclude' filtering but I didn't see the options on the CLI.
