### PR TITLE
conflict with gem 'settler'

### DIFF
--- a/lib/rails_erd/diagram.rb
+++ b/lib/rails_erd/diagram.rb
@@ -151,7 +151,7 @@ module RailsERD
     def filtered_entities
       @domain.entities.reject { |entity|
         options.exclude && entity.model && [options.exclude].flatten.include?(entity.name.to_sym) or
-        options.only && entity.model && ![options.only].flatten.include?(entity.name.to_sym) or
+        options[:only] && entity.model && ![options[:only]].flatten.include?(entity.name.to_sym) or
         !options.inheritance && entity.specialized? or
         !options.polymorphism && entity.generalized? or
         !options.disconnected && entity.disconnected?

--- a/test/unit/diagram_test.rb
+++ b/test/unit/diagram_test.rb
@@ -341,4 +341,30 @@ class DiagramTest < ActiveSupport::TestCase
     Object.const_set :Whisky, Class.new(Beverage)
     assert_equal [], retrieve_attribute_lists(:inheritance => true)[Whisky].map(&:name)
   end
+
+  test "conflict with settler" do
+    Hash.class_eval do
+      #simulate the method 'only' defined in settler 
+      # (https://github.com/moiristo/settler/blob/master/lib/hash_extension.rb#L4)
+      def only(*selected_keys)
+        {}
+      end
+    end
+
+    begin
+      assert_equal({}, RailsERD.options.only)
+
+      create_model "Book"
+      create_model "Author"
+      assert_equal [Book], retrieve_entities(:only => [:Book]).map(&:model)
+    
+    rescue
+      raise $!
+    ensure
+      Hash.class_eval do
+        undef_method(:only)
+      end
+    end
+  end
+
 end


### PR DESCRIPTION
the gem 'settler' defines the method 'only' on Hash and it conflicts
with the option 'only' used to specified the models to include. This
solves some issue related to the error "No entities found; create your
models first!"