### PR TITLE
Provide `sort` option to keep attributes original order

### DIFF
--- a/lib/rails_erd.rb
+++ b/lib/rails_erd.rb
@@ -58,6 +58,7 @@ module RailsERD
     :notation, :simple,
     :orientation, :horizontal,
     :polymorphism, false,
+    :sort, true,
     :warn, true,
     :title, true,
     :exclude, nil,

--- a/lib/rails_erd/domain/attribute.rb
+++ b/lib/rails_erd/domain/attribute.rb
@@ -10,7 +10,8 @@ module RailsERD
 
       class << self
         def from_model(domain, model) # @private :nodoc:
-          model.columns.collect { |column| new(domain, model, column) }.sort
+          attributes = model.columns.collect { |column| new(domain, model, column) }
+          RailsERD.options[:sort] ? attributes.sort : attributes
         end
       end
 

--- a/test/unit/attribute_test.rb
+++ b/test/unit/attribute_test.rb
@@ -30,6 +30,20 @@ class AttributeTest < ActiveSupport::TestCase
       Domain::Attribute.from_model(Domain.new, Foo).reject(&:primary_key?).first.column
   end
 
+  test "from_model should return attributes with sorted order if sort is true" do
+    RailsERD.options[:sort] = true
+    create_model "Foo"
+    add_column :foos, :a, :string
+    assert_equal %w{a id}, Domain::Attribute.from_model(Domain.new, Foo).map(&:name)
+  end
+
+  test "from_model should return attributes with original order if sort is false" do
+    RailsERD.options[:sort] = false
+    create_model "Foo"
+    add_column :foos, :a, :string
+    assert_equal %w{id a}, Domain::Attribute.from_model(Domain.new, Foo).map(&:name)
+  end
+
   test "spaceship should sort attributes by name" do
     create_model "Foo", :a => :string, :b => :string, :c => :string
     a = create_attribute(Foo, "a")


### PR DESCRIPTION
I like to arrange column order. In fact, I always use :after option when I add column.
So I want to output attributes as original order on diagram.