### PR TITLE
Test for primary key by using primary_key method

### DIFF
--- a/lib/rails_erd/domain/attribute.rb
+++ b/lib/rails_erd/domain/attribute.rb
@@ -49,7 +49,7 @@ module RailsERD
 
       # Returns +true+ if this attribute is the primary key of the entity.
       def primary_key?
-        column.primary
+        @model.primary_key.to_s == name.to_s
       end
 
       # Returns +true+ if this attribute is used as a foreign key for any


### PR DESCRIPTION
The `column.primary` method seems to have been deprecated. 