### PR TITLE
Add installation of graphviz to before_install

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,8 @@ rvm:
   - jruby
 before_install:
   - gem install bundler
+  - sudo apt-get update -qq
+  - sudo apt-get install -qq graphviz
 script: bundle exec rake
 matrix:
   allow_failures:


### PR DESCRIPTION
Cargo culting this a bit from other examples I've seen. If this works, it should fix our failing TravisCI runs, which are complaining about Graphviz not being installed.
