### PR TITLE
Use NullObjects to avoid bug where generalized or specialization could b...

### DIFF
--- a/lib/rails_erd/domain/specialization.rb
+++ b/lib/rails_erd/domain/specialization.rb
@@ -49,7 +49,9 @@ module RailsERD
       attr_reader :specialized
 
       def initialize(domain, generalized, specialized) # @private :nodoc:
-        @domain, @generalized, @specialized = domain, generalized, specialized
+        @domain = domain
+        @generalized = generalized || NullGeneralized.new
+        @specialized = specialized || NullSpecialization.new
       end
 
       def generalization?
@@ -64,6 +66,18 @@ module RailsERD
 
       def <=>(other) # @private :nodoc:
         (generalized.name <=> other.generalized.name).nonzero? or (specialized.name <=> other.specialized.name)
+      end
+    end
+
+    class NullSpecialization
+      def name
+        ""
+      end
+    end
+
+    class NullGeneralized
+      def name
+        ""
       end
     end
   end


### PR DESCRIPTION
...e null. Fixes #88 
