### PR TITLE
Add Ruby 2.1.x to TravisCI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 language: ruby
 rvm:
   - 1.9.3
+  - 2.1.0
   - jruby
 before_install:
   - gem install bundler


### PR DESCRIPTION
I've been working with this under 2.1.5 without problems, so I doubt this will have much impact.

Fixes #106 
