### PR TITLE
rails 4.x undefined method 'primary' 

### DIFF
--- a/lib/rails_erd/domain/attribute.rb
+++ b/lib/rails_erd/domain/attribute.rb
@@ -49,7 +49,7 @@ module RailsERD
 
       # Returns +true+ if this attribute is the primary key of the entity.
       def primary_key?
-        column.primary
+        @model.primary_key == column.name
       end
 
       # Returns +true+ if this attribute is used as a foreign key for any


### PR DESCRIPTION
rails 4.2.0
Failed: NoMethodError: undefined method `primary' for #<ActiveRecord::ConnectionAdapters::AbstractMysqlAdapter::Column:0x007f960e274ce0>