### PR TITLE
Add license to gemspec

### DIFF
--- a/rails-erd.gemspec
+++ b/rails-erd.gemspec
@@ -11,6 +11,7 @@ Gem::Specification.new do |s|
   s.homepage    = "https://github.com/voormedia/rails-erd"
   s.summary     = %q{Entity-relationship diagram for your Rails models.}
   s.description = %q{Automatically generate an entity-relationship diagram (ERD) for your Rails models.}
+  s.license     = "MIT"
 
   s.rubyforge_project = "rails-erd"
 


### PR DESCRIPTION
I was trying to determine the licenses for my dependencies. I found that the RubyGems API will return the license, but only if it is specified in your gemspec file.