### PR TITLE
Fix duplicated key :fontsize

### DIFF
--- a/lib/rails_erd/diagram/graphviz.rb
+++ b/lib/rails_erd/diagram/graphviz.rb
@@ -77,13 +77,12 @@ module RailsERD
       # Default edge attributes.
       EDGE_ATTRIBUTES = {
         fontname:      FONTS[:normal],
-        fontsize:      8,
+        fontsize:      7,
         dir:           :both,
         arrowsize:     0.9,
         penwidth:      1.0,
         labelangle:    32,
-        labeldistance: 1.8,
-        fontsize:      7
+        labeldistance: 1.8
       }
 
       module Simple


### PR DESCRIPTION
Fix the error:

    lib/rails_erd/diagram/graphviz.rb:77: warning: duplicated key at line 83 ignored: :fontsize