### PR TITLE
Parse Exclude and Only options into array, Process as Strings. 

### DIFF
--- a/lib/rails_erd/cli.rb
+++ b/lib/rails_erd/cli.rb
@@ -118,7 +118,7 @@ module RailsERD
           if key.start_with? "no_"
             opts[key.gsub("no_", "").to_sym] = !value
           elsif value.to_s.include? ","
-            opts[key.to_sym] = value.split(",").map(&:to_sym)
+            opts[key.to_sym] = value.split(",").map(&:to_s)
           else
             opts[key.to_sym] = value
           end

--- a/lib/rails_erd/config.rb
+++ b/lib/rails_erd/config.rb
@@ -60,12 +60,15 @@ module RailsERD
       when :filetype, :notation, :orientation
         value.to_sym
 
+      # [<string>]
+      when :only, :exclude
+        Array(value).join(",").split(",").map { |v| v.strip }
       # true | false
       when :disconnected, :indirect, :inheritance, :markup, :polymorphism, :warn
         !!value
 
       # nil | <string>
-      when :filename, :only, :exclude
+      when :filename
         value.nil? ? nil : value.to_s
 
       # true | false | <string>

--- a/lib/rails_erd/diagram.rb
+++ b/lib/rails_erd/diagram.rb
@@ -150,8 +150,8 @@ module RailsERD
 
     def filtered_entities
       @domain.entities.reject { |entity|
-        options.exclude && entity.model && [options.exclude].flatten.include?(entity.name.to_sym) or
-        options.only && entity.model && ![options.only].flatten.include?(entity.name.to_sym) or
+        options.exclude && entity.model && [options.exclude].flatten.include?(entity.name.to_s) or
+        options.only && entity.model && ![options.only].flatten.include?(entity.name.to_s) or
         !options.inheritance && entity.specialized? or
         !options.polymorphism && entity.generalized? or
         !options.disconnected && entity.disconnected?

--- a/test/support_files/erdconfig.exclude.example
+++ b/test/support_files/erdconfig.exclude.example
@@ -13,6 +13,6 @@ orientation: horizontal
 polymorphism: false
 warn: true
 title: sample title
-exclude:
+exclude: Book,Author
 only: 
 

--- a/test/unit/config_test.rb
+++ b/test/unit/config_test.rb
@@ -24,8 +24,30 @@ class ConfigTest < ActiveSupport::TestCase
       polymorphism: false,
       warn:         true,
       title:        "sample title",
-      exclude:      nil,
-      only:         nil
+      exclude:      [],
+      only:         []
+    }
+    assert_equal expected_hash, RailsERD::Config.load
+  end
+
+  test "load_config_file should return a hash from USER_WIDE_CONFIG_FILE when only USER_WIDE_CONFIG_FILE exists." do
+    set_user_config_file_to("erdconfig.exclude.example")
+
+    expected_hash = {
+      attributes:   [:content, :foreign_key, :inheritance],
+      disconnected: true,
+      filename:     "erd",
+      filetype:     :pdf,
+      indirect:     true,
+      inheritance:  false,
+      markup:       true,
+      notation:     :simple,
+      orientation:  :horizontal,
+      polymorphism: false,
+      warn:         true,
+      title:        "sample title",
+      exclude:      ['Book', 'Author'],
+      only:         []
     }
     assert_equal expected_hash, RailsERD::Config.load
   end
@@ -56,8 +78,8 @@ class ConfigTest < ActiveSupport::TestCase
       polymorphism: false,
       warn:         true,
       title:        "sample title",
-      exclude:      nil,
-      only:         nil
+      exclude:      [],
+      only:         []
     }
     assert_equal expected_hash, RailsERD::Config.load
   end

--- a/test/unit/diagram_test.rb
+++ b/test/unit/diagram_test.rb
@@ -126,27 +126,27 @@ class DiagramTest < ActiveSupport::TestCase
   test "generate should filter excluded entity" do
     create_model "Book"
     create_model "Author"
-    assert_equal [Book], retrieve_entities(:exclude => :Author).map(&:model)
+    assert_equal [Book], retrieve_entities(:exclude => ['Author']).map(&:model)
   end
 
   test "generate should filter excluded entities" do
     create_model "Book"
     create_model "Author"
     create_model "Editor"
-    assert_equal [Book], retrieve_entities(:exclude => [:Author, :Editor]).map(&:model)
+    assert_equal [Book], retrieve_entities(:exclude => ['Author', 'Editor']).map(&:model)
   end
 
   test "generate should include only specified entity" do
     create_model "Book"
     create_model "Author"
-    assert_equal [Book], retrieve_entities(:only => [:Book]).map(&:model)
+    assert_equal [Book], retrieve_entities(:only => ['Book']).map(&:model)
   end
 
   test "generate should include only specified entities" do
     create_model "Book"
     create_model "Author"
     create_model "Editor"
-    assert_equal [Author, Editor], retrieve_entities(:only => [:Author, :Editor]).map(&:model)
+    assert_equal [Author, Editor], retrieve_entities(:only => ['Author', 'Editor']).map(&:model)
   end
 
   test "generate should filter disconnected entities if disconnected is false" do


### PR DESCRIPTION
Fixes #50  handles only, and exclude as strings, properly parse config, and ensure we don't swap from symbol to string and back.