### PR TITLE
Drop support for spaces in output filenames

### DIFF
--- a/lib/rails_erd/diagram/graphviz.rb
+++ b/lib/rails_erd/diagram/graphviz.rb
@@ -194,9 +194,10 @@ module RailsERD
 
       save do
         raise "Saving diagram failed!\nOutput directory '#{File.dirname(filename)}' does not exist." unless File.directory?(File.dirname(filename))
+
         begin
           # GraphViz doesn't like spaces in the filename
-          graph.output(filetype => filename.gsub(/\s/,"\\ "))
+          graph.output(filetype => filename.gsub(/\s/,"_"))
           filename
         rescue RuntimeError => e
           raise "Saving diagram failed!\nGraphviz produced errors. Verify it " +

--- a/test/unit/graphviz_test.rb
+++ b/test/unit/graphviz_test.rb
@@ -94,7 +94,7 @@ class GraphvizTest < ActiveSupport::TestCase
   test "create should create output for filenames that have spaces" do
     create_simple_domain
     Diagram::Graphviz.create :filename => "erd with spaces"
-    assert File.exists?("erd with spaces.png")
+    assert File.exists?("erd_with_spaces.png")
   end
 
   test "create should write to file with dot extension without requiring graphviz" do


### PR DESCRIPTION
This is a bit of an experiment. As I was looking into JRuby test failures this morning, I was having trouble getting JRuby to play nice with filenames with spaces, and I really wonder how much we need this (especially if its causing xRuby problems). Mostly I'm filing this to see if anyone cares, and if TravisCI feels any happier.

Comments welcome.