### PR TITLE
Mark primary and unique keys, add PK sorting option

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,7 @@ warn: true
 title: sample title
 exclude: null
 only: null
+prepend_primary: false
 ```
 
 

--- a/examples/erdconfig.example
+++ b/examples/erdconfig.example
@@ -16,3 +16,4 @@ warn: true
 title: sample title
 exclude: null
 only: null
+prepend_primary: false

--- a/lib/rails_erd.rb
+++ b/lib/rails_erd.rb
@@ -50,7 +50,8 @@ module RailsERD
         :warn, true,
         :title, true,
         :exclude, nil,
-        :only, nil
+        :only, nil,
+        :prepend_primary, false
       ]
     end
   end

--- a/lib/rails_erd/cli.rb
+++ b/lib/rails_erd/cli.rb
@@ -57,6 +57,12 @@ Choice.options do
     desc "Filter to exclude listed models in diagram."
   end
 
+  option :prepend_primary do
+    long "--prepend_primary=BOOLEAN"
+    desc "Ensure primary key is at start of attribute list"
+    default "false"
+  end
+
   separator ""
   separator "Output options:"
 

--- a/lib/rails_erd/cli.rb
+++ b/lib/rails_erd/cli.rb
@@ -57,6 +57,12 @@ Choice.options do
     desc "Filter to exclude listed models in diagram."
   end
 
+  option :sort do
+    long "--sort=BOOLEAN"
+    desc "Sort attribute list alphabetically"
+    default "false"
+  end
+
   option :prepend_primary do
     long "--prepend_primary=BOOLEAN"
     desc "Ensure primary key is at start of attribute list"

--- a/lib/rails_erd/domain/attribute.rb
+++ b/lib/rails_erd/domain/attribute.rb
@@ -11,7 +11,19 @@ module RailsERD
       class << self
         def from_model(domain, model) # @private :nodoc:
           attributes = model.columns.collect { |column| new(domain, model, column) }
-          RailsERD.options[:sort] ? attributes.sort : attributes
+          attributes.sort! if RailsERD.options[:sort]
+
+          if RailsERD.options[:prepend_primary]
+            primary_key = ActiveRecord::Base.get_primary_key(model)
+            primary = attributes.detect{ |column| column.name == primary_key }
+
+            if primary
+              attributes.delete(primary)
+              attributes.unshift(primary)
+            end
+          end
+
+          attributes
         end
       end
 

--- a/lib/rails_erd/domain/attribute.rb
+++ b/lib/rails_erd/domain/attribute.rb
@@ -60,6 +60,10 @@ module RailsERD
         !column.null or @model.validators_on(name).map(&:kind).include?(:presence)
       end
 
+       def unique?
+         @model.validators_on(name).map(&:kind).include?(:uniqueness)
+       end
+
       # Returns +true+ if this attribute is the primary key of the entity.
       def primary_key?
         @model.primary_key.to_s == name.to_s
@@ -106,7 +110,10 @@ module RailsERD
       def type_description
         type.to_s.tap do |desc|
           desc << " #{limit_description}" if limit_description
-          desc << " ∗" if mandatory? # Add a hair space + low asterisk (Unicode characters).
+          desc << " ∗" if mandatory? && !primary_key? # Add a hair space + low asterisk (Unicode characters)
+          desc << " U" if unique? && !primary_key? && !foreign_key? # Add U if unique but non-key
+          desc << " PK" if primary_key?
+          desc << " FK" if foreign_key?
         end
       end
 

--- a/lib/rails_erd/domain/entity.rb
+++ b/lib/rails_erd/domain/entity.rb
@@ -40,7 +40,7 @@ module RailsERD
 
       # Returns an array of attributes for this entity.
       def attributes
-        @attributes ||= if generalized? then [] else Attribute.from_model(domain, model) end
+        @attributes ||= generalized? ? [] : Attribute.from_model(domain, model)
       end
 
       # Returns an array of all relationships that this entity has with other

--- a/test/unit/attribute_test.rb
+++ b/test/unit/attribute_test.rb
@@ -44,6 +44,16 @@ class AttributeTest < ActiveSupport::TestCase
     assert_equal %w{id a}, Domain::Attribute.from_model(Domain.new, Foo).map(&:name)
   end
 
+  test "from_model should return attributes with PK first if sort is false and prepend_primary is true" do
+    RailsERD.options[:sort]            = false
+    RailsERD.options[:prepend_primary] = true
+
+    create_model "Foo"
+    add_column :foos, :a, :string
+
+    assert_equal %w{id a}, Domain::Attribute.from_model(Domain.new, Foo).map(&:name)
+  end
+
   test "spaceship should sort attributes by name" do
     create_model "Foo", :a => :string, :b => :string, :c => :string
     a = create_attribute(Foo, "a")


### PR DESCRIPTION
This is a rewrite of #83. @eagleas did solid work, and since we added configuration options, I thought I'd rework their code to take advantage of the need to at least rebase #83 and make sure PK sorting was a selectable option. 

This also adds marking primary, unique, and foreign keys as such on the diagram; if anyone thinks this should be a command-line option, it should be trivial to add, and would make a nice beginner/new-to-the-project PR.