### PR TITLE
Fix some rubocop warnings

### DIFF
--- a/examples/identity.rb
+++ b/examples/identity.rb
@@ -33,7 +33,7 @@ class Identity < RailsERD::Diagram
 
   def association_macro(relationship)
     name = relationship.destination.name.underscore
-    macro = case
+    case
     when relationship.to_one?       then "has_one :#{name}"
     when relationship.many_to_many? then "has_and_belongs_to_many :#{name.pluralize}"
     when relationship.to_many?      then "has_many :#{name.pluralize}"
@@ -42,7 +42,7 @@ class Identity < RailsERD::Diagram
 
   def reverse_association_macro(relationship)
     name = relationship.source.name.underscore
-    macro = case
+    case
     when relationship.many_to?      then "has_and_belongs_to_many :#{name.pluralize}"
     when relationship.one_to?       then "belongs_to :#{name}"
     end

--- a/lib/rails_erd/domain/relationship.rb
+++ b/lib/rails_erd/domain/relationship.rb
@@ -63,7 +63,8 @@ module RailsERD
 
       def initialize(domain, associations) # @private :nodoc:
         @domain = domain
-        @reverse_associations, @forward_associations = *unless any_habtm?(associations)
+        @reverse_associations, @forward_associations =
+        unless any_habtm?(associations)
           associations.partition(&:belongs_to?)
         else
           # Many-to-many associations don't have a clearly defined direction.

--- a/lib/rails_erd/domain/relationship.rb
+++ b/lib/rails_erd/domain/relationship.rb
@@ -64,13 +64,13 @@ module RailsERD
       def initialize(domain, associations) # @private :nodoc:
         @domain = domain
         @reverse_associations, @forward_associations =
-        unless any_habtm?(associations)
-          associations.partition(&:belongs_to?)
-        else
+        if any_habtm?(associations)
           # Many-to-many associations don't have a clearly defined direction.
           # We sort by name and use the first model as the source.
           source = associations.map(&:active_record).sort_by(&:name).first
           associations.partition { |association| association.active_record != source }
+        else
+          associations.partition(&:belongs_to?)
         end
 
         assoc = @forward_associations.first || @reverse_associations.first

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -34,7 +34,7 @@ class ActiveSupport::TestCase
   def add_column(*args)
     ActiveRecord::Schema.instance_eval do
       suppress_messages do
-        add_column *args
+        add_column(*args)
       end
     end
     ActiveRecord::Base.clear_cache!


### PR DESCRIPTION
    == lib/rails_erd/domain/relationship.rb ==
    W: 73:  9: end at 73, 8 is not aligned with unless at 66, 56

    == examples/identity.rb ==
    W: 36:  5: Useless assignment to variable - macro.
    W: 45:  5: Useless assignment to variable - macro.

    == test/test_helper.rb ==
    W: 37: 20: Ambiguous splat operator. Parenthesize the method arguments if it's surely a splat operator, or add a whitespace to the right of the * if it should be a multiplication.
