### PR TITLE
Improve Attribute#from_model

### DIFF
--- a/lib/rails_erd/domain/attribute.rb
+++ b/lib/rails_erd/domain/attribute.rb
@@ -14,13 +14,18 @@ module RailsERD
           attributes.sort! if RailsERD.options[:sort]
 
           if RailsERD.options[:prepend_primary]
-            primary_key = ActiveRecord::Base.get_primary_key(model)
-            primary = attributes.detect{ |column| column.name == primary_key }
+            attributes = prepend_primary(model, attributes)
+          end
 
-            if primary
-              attributes.delete(primary)
-              attributes.unshift(primary)
-            end
+          attributes
+        end
+
+        def prepend_primary(model, attributes)
+          primary_key = ActiveRecord::Base.get_primary_key(model)
+          primary = attributes.index { |column| column.name == primary_key }
+
+          if primary
+            attributes[primary], attributes[0] = attributes[0], attributes[primary]
           end
 
           attributes

--- a/test/unit/attribute_test.rb
+++ b/test/unit/attribute_test.rb
@@ -45,7 +45,7 @@ class AttributeTest < ActiveSupport::TestCase
   end
 
   test "from_model should return attributes with PK first if sort is false and prepend_primary is true" do
-    RailsERD.options[:sort]            = false
+    RailsERD.options[:sort]            = true
     RailsERD.options[:prepend_primary] = true
 
     create_model "Foo"

--- a/test/unit/attribute_test.rb
+++ b/test/unit/attribute_test.rb
@@ -44,7 +44,7 @@ class AttributeTest < ActiveSupport::TestCase
     assert_equal %w{id a}, Domain::Attribute.from_model(Domain.new, Foo).map(&:name)
   end
 
-  test "from_model should return attributes with PK first if sort is false and prepend_primary is true" do
+  test "from_model should return attributes with PK first if prepend_primary is true" do
     RailsERD.options[:sort]            = true
     RailsERD.options[:prepend_primary] = true
 


### PR DESCRIPTION
Index + swap should be a lot faster than delete + unshift. Delete has to scan the whole array until it finds the object to delete, and the same goes for detect, so it does more work than nedeed.
   
I also changed the related test because it wasn't really testing anything, I commented the whole prepend_primary code and the test still passed because the primary key "id" is already first (original order).