### PR TITLE
Auto generate diagram on db:migrate

### DIFF
--- a/lib/generators/erd/USAGE
+++ b/lib/generators/erd/USAGE
@@ -1,0 +1,4 @@
+Add a .rake file that automatically generate the graphical models when you do 
+a db:migrate in development mode:
+
+    rails generate erd:install

--- a/lib/generators/erd/install_generator.rb
+++ b/lib/generators/erd/install_generator.rb
@@ -1,0 +1,14 @@
+module Erd
+  module Generators
+    class InstallGenerator < Rails::Generators::Base
+      desc "Copy rails-erd rakefiles for automatic graphic generation"
+      source_root File.expand_path('../templates', __FILE__)
+
+      # copy rake tasks
+      def copy_tasks
+        template "auto_generate_diagram.rake", "lib/tasks/auto_generate_diagram.rake"
+      end
+
+    end
+  end
+end

--- a/lib/generators/erd/templates/auto_generate_diagram.rake
+++ b/lib/generators/erd/templates/auto_generate_diagram.rake
@@ -1,0 +1,6 @@
+# NOTE: only doing this in development as some production environments (Heroku)
+# NOTE: are sensitive to local FS writes, and besides -- it's just not proper
+# NOTE: to have a dev-mode tool do its thing in production.
+if Rails.env.development?
+  Erd.load_tasks
+end

--- a/lib/tasks/auto_generate_diagram.rake
+++ b/lib/tasks/auto_generate_diagram.rake
@@ -1,0 +1,21 @@
+namespace :db do
+  task :migrate do
+    ERDGraph::Migration.update_model
+  end
+
+  namespace :migrate do
+    [:change, :up, :down, :reset, :redo].each do |t|
+      task t do
+        ERDGraph::Migration.update_model
+      end
+    end
+  end
+end
+
+module ERDGraph
+  class Migration
+    def self.update_model
+      Rake::Task['erd'].invoke
+    end
+  end
+end


### PR DESCRIPTION
Hey @kerrizor 
I'm following your advice. I put that quickly through, on the model of the annotate_models gem.

with an install generator you pull a stupid rake task that loads the erd rake tasks. And the rake task I created plugs itself on the db:migrate and co tasks

I must say I have not tested that in the context of the gem cause I really can't spend the time right now but if you are willing to spend 1 hour, it should not be too hard to have it working (hopefully it does already)

Cheers
Greg