### PR TITLE
Fix #42 for rake tasks

### DIFF
--- a/lib/rails_erd/tasks.rake
+++ b/lib/rails_erd/tasks.rake
@@ -8,7 +8,7 @@ namespace :erd do
       RailsERD.options[option.to_sym] = case ENV[option]
       when "true", "yes" then true
       when "false", "no" then false
-      when /,/ then ENV[option].split(/\s*,\s*/).map(&:to_sym)
+      when /,/ then ENV[option].split(/\s*,\s*/)
       else ENV[option].to_sym
       end
     end

--- a/test/unit/rake_task_test.rb
+++ b/test/unit/rake_task_test.rb
@@ -160,6 +160,6 @@ Error occurred while loading application: FooBar (RuntimeError)
   test "options task should set known array command line options" do
     ENV["attributes"] = "content,timestamps"
     Rake::Task["erd:options"].execute
-    assert_equal [:content, :timestamps], RailsERD.options.attributes
+    assert_equal %w[content timestamps], RailsERD.options.attributes
   end
 end


### PR DESCRIPTION
The original issue #42 doesn't specifically states whether the problem
happens by using the rake task or CLI, but while the CLI is fixed by
later changes, the rake task is still broken. It tries to compare model
names that comes in an array of symbols via
`options.only`/`options.exclude` against String model names.

This keeps both CLIs (rake and binary) consistent in handling
comma-separated values. The binary CLI splits into an array of strings,
which the rake task should too.