### PR TITLE
Fixed 'No entities found' error when using filter

### DIFF
--- a/lib/rails_erd/diagram.rb
+++ b/lib/rails_erd/diagram.rb
@@ -150,8 +150,8 @@ module RailsERD
 
     def filtered_entities
       @domain.entities.reject { |entity|
-        options.exclude && entity.model && [options.exclude].flatten.include?(entity.name.to_s) or
-        options.only && entity.model && ![options.only].flatten.include?(entity.name.to_s) or
+        options.exclude && entity.model && [options.exclude].flatten.include?(entity.name.to_sym) or
+        options.only && entity.model && ![options.only].flatten.include?(entity.name.to_sym) or
         !options.inheritance && entity.specialized? or
         !options.polymorphism && entity.generalized? or
         !options.disconnected && entity.disconnected?

--- a/test/unit/diagram_test.rb
+++ b/test/unit/diagram_test.rb
@@ -126,27 +126,27 @@ class DiagramTest < ActiveSupport::TestCase
   test "generate should filter excluded entity" do
     create_model "Book"
     create_model "Author"
-    assert_equal [Book], retrieve_entities(:exclude => ['Author']).map(&:model)
+    assert_equal [Book], retrieve_entities(:exclude => [:Author]).map(&:model)
   end
 
   test "generate should filter excluded entities" do
     create_model "Book"
     create_model "Author"
     create_model "Editor"
-    assert_equal [Book], retrieve_entities(:exclude => ['Author', 'Editor']).map(&:model)
+    assert_equal [Book], retrieve_entities(:exclude => [:Author, :Editor]).map(&:model)
   end
 
   test "generate should include only specified entity" do
     create_model "Book"
     create_model "Author"
-    assert_equal [Book], retrieve_entities(:only => ['Book']).map(&:model)
+    assert_equal [Book], retrieve_entities(:only => [:Book]).map(&:model)
   end
 
   test "generate should include only specified entities" do
     create_model "Book"
     create_model "Author"
     create_model "Editor"
-    assert_equal [Author, Editor], retrieve_entities(:only => ['Author', 'Editor']).map(&:model)
+    assert_equal [Author, Editor], retrieve_entities(:only => [:Author, :Editor]).map(&:model)
   end
 
   test "generate should filter disconnected entities if disconnected is false" do


### PR DESCRIPTION
Error "No entities found; create your models first!" occurred when using a 'only' or 'exclude' filter.
options.only/options.exclude contains an array of symbols and not strings.