### PR TITLE
Fix bug; Should check option as symbol

### DIFF
--- a/lib/rails_erd/diagram.rb
+++ b/lib/rails_erd/diagram.rb
@@ -150,8 +150,8 @@ module RailsERD
 
     def filtered_entities
       @domain.entities.reject { |entity|
-        options.exclude && entity.model && [options.exclude].flatten.include?(entity.name.to_sym) or
-        options.only && entity.model && ![options.only].flatten.include?(entity.name.to_sym) or
+        options.exclude && entity.model && [options.exclude].flatten.map(&:to_sym).include?(entity.name.to_sym) or
+        options.only && entity.model && ![options.only].flatten.map(&:to_sym).include?(entity.name.to_sym) or
         !options.inheritance && entity.specialized? or
         !options.polymorphism && entity.generalized? or
         !options.disconnected && entity.disconnected?


### PR DESCRIPTION
If run erd with only & exclude option, options are passed as string. So, "filtered_entities" raise error.