### PR TITLE
The only and exclude options weren't working for me...

### DIFF
--- a/lib/rails_erd/diagram.rb
+++ b/lib/rails_erd/diagram.rb
@@ -150,8 +150,8 @@ module RailsERD
 
     def filtered_entities
       @domain.entities.reject { |entity|
-        options.exclude && entity.model && [options.exclude].flatten.include?(entity.name.to_sym) or
-        options.only && entity.model && ![options.only].flatten.include?(entity.name.to_sym) or
+        options.exclude && entity.model && [options.exclude].flatten.map(&:to_sym).include?(entity.name.to_sym) or
+        options.only && entity.model && ![options.only].flatten.map(&:to_sym).include?(entity.name.to_sym) or
         !options.inheritance && entity.specialized? or
         !options.polymorphism && entity.generalized? or
         !options.disconnected && entity.disconnected?

--- a/test/unit/diagram_test.rb
+++ b/test/unit/diagram_test.rb
@@ -149,6 +149,13 @@ class DiagramTest < ActiveSupport::TestCase
     assert_equal [Author, Editor], retrieve_entities(:only => [:Author, :Editor]).map(&:model)
   end
 
+  test "generate should include only specified entities (With the class names as strings)" do
+    create_model "Book"
+    create_model "Author"
+    create_model "Editor"
+    assert_equal [Author, Editor], retrieve_entities(:only => ['Author', 'Editor']).map(&:model)
+  end
+
   test "generate should filter disconnected entities if disconnected is false" do
     create_model "Book", :author => :references do
       belongs_to :author


### PR DESCRIPTION
I am in a ruby '2.2.1' and a 'rails', '4.2.1' environment, and I tried to run a simple ERD with the only option. With a single entity it worked, but with multiple it did not.


bundle exec rake erd only='User' (worked)
bundle exec rake erd only='User,Address' (resulting in "No entities found; create your models first!")

So, I found that at least in my environment the options are string and not symbols as expected based on the tests. So I added a new test, passed in strings, and made the code handle both scenarios.

