### PR TITLE
Fix limit for PostGIS geometry column types

### DIFF
--- a/lib/rails_erd/domain/attribute.rb
+++ b/lib/rails_erd/domain/attribute.rb
@@ -125,6 +125,7 @@ module RailsERD
       # Returns any non-standard limit for this attribute. If a column has no
       # limit or uses a default database limit, this method returns +nil+.
       def limit
+        return if native_type == 'geometry'
         return column.limit.to_i if column.limit != native_type[:limit] and column.limit.respond_to?(:to_i)
         column.precision.to_i if column.precision != native_type[:precision] and column.precision.respond_to?(:to_i)
       end


### PR DESCRIPTION
When you are using PostGIS geometry column types such as st_point:

```
  create_table "businesses", force: :cascade do |t|
    t.geometry "latlng",     limit: {:srid=>0, :type=>"point"}
    t.string   "phone",                                         null: false
    t.datetime "created_at",                                    null: false
    t.datetime "updated_at",                                    null: false
  end
```

Running `rake erd` fails with the following error:
```
TypeError: no implicit conversion of Symbol into Integer
/Users/yosriady/.rvm/gems/ruby-2.2.0/gems/rails-erd-1.4.1/lib/rails_erd/domain/attribute.rb:133:in `[]'
/Users/yosriady/.rvm/gems/ruby-2.2.0/gems/rails-erd-1.4.1/lib/rails_erd/domain/attribute.rb:133:in `limit'
/Users/yosriady/.rvm/gems/ruby-2.2.0/gems/rails-erd-1.4.1/lib/rails_erd/domain/attribute.rb:147:in `limit_description'
/Users/yosriady/.rvm/gems/ruby-2.2.0/gems/rails-erd-1.4.1/lib/rails_erd/domain/attribute.rb:117:in `block in type_description'
/Users/yosriady/.rvm/gems/ruby-2.2.0/gems/rails-erd-1.4.1/lib/rails_erd/domain/attribute.rb:116:in `tap'
/Users/yosriady/.rvm/gems/ruby-2.2.0/gems/rails-erd-1.4.1/lib/rails_erd/domain/attribute.rb:116:in `type_description'
```

The issue was because in the following `limit` method:
```
      def limit
        return column.limit.to_i if column.limit != native_type[:limit] and column.limit.respond_to?(:to_i)
        column.precision.to_i if column.precision != native_type[:precision] and column.precision.respond_to?(:to_i)
      end
```

`native_type` returns a string "geometry", and thus native_type[:limit] fails for all geometry column types.

The proposed fix:
```
      def limit
        **return if native_type == 'geometry'**
        return column.limit.to_i if column.limit != native_type[:limit] and column.limit.respond_to?(:to_i)
        column.precision.to_i if column.precision != native_type[:precision] and column.precision.respond_to?(:to_i)
      end
```

Edit: I'm working on resolving the breaking test.