### PR TITLE
return nil if native_type is geography

### DIFF
--- a/lib/rails_erd/domain/attribute.rb
+++ b/lib/rails_erd/domain/attribute.rb
@@ -125,7 +125,7 @@ module RailsERD
       # Returns any non-standard limit for this attribute. If a column has no
       # limit or uses a default database limit, this method returns +nil+.
       def limit
-        return if native_type == 'geometry' native_type == 'geography'
+        return if native_type == 'geometry' || native_type == 'geography'
         return column.limit.to_i if column.limit != native_type[:limit] and column.limit.respond_to?(:to_i)
         column.precision.to_i if column.precision != native_type[:precision] and column.precision.respond_to?(:to_i)
       end

--- a/lib/rails_erd/domain/attribute.rb
+++ b/lib/rails_erd/domain/attribute.rb
@@ -125,7 +125,7 @@ module RailsERD
       # Returns any non-standard limit for this attribute. If a column has no
       # limit or uses a default database limit, this method returns +nil+.
       def limit
-        return if native_type == 'geometry'
+        return if native_type == 'geometry' native_type == 'geography'
         return column.limit.to_i if column.limit != native_type[:limit] and column.limit.respond_to?(:to_i)
         column.precision.to_i if column.precision != native_type[:precision] and column.precision.respond_to?(:to_i)
       end


### PR DESCRIPTION
This PR will return nil in the `limit` method of `rails_erd/domain/attribute.rb` -- this problem was causing a crash with our models, and this fixes that.

Feel free to take it or leave it -- I'll be using my own hacked-up version for now either way. Let me know if I can help with this any more.