### PR TITLE
Fixed horizontally graph when vertical was wanted and viceversa

### DIFF
--- a/lib/rails_erd/diagram/graphviz.rb
+++ b/lib/rails_erd/diagram/graphviz.rb
@@ -183,7 +183,7 @@ module RailsERD
         EDGE_ATTRIBUTES.each  { |attribute, value| graph.edge[attribute] = value }
 
         # Switch rank direction if we're creating a vertically oriented graph.
-        graph[:rankdir] = :TB if options.orientation == :vertical
+        graph[:rankdir] = (options.orientation == :vertical) ? :LR : :TB
 
         # Title of the graph itself.
         graph[:label] = "#{title}\\n\\n" if title

--- a/test/unit/graphviz_test.rb
+++ b/test/unit/graphviz_test.rb
@@ -59,14 +59,14 @@ class GraphvizTest < ActiveSupport::TestCase
     end
   end
 
-  test "rank direction should be lr for horizontal orientation" do
+  test "rank direction should be tb for horizontal orientation" do
     create_simple_domain
-    assert_equal '"LR"', diagram(:orientation => :horizontal).graph[:rankdir].to_s
+    assert_equal '"TB"', diagram(:orientation => :horizontal).graph[:rankdir].to_s
   end
 
-  test "rank direction should be tb for vertical orientation" do
+  test "rank direction should be lr for vertical orientation" do
     create_simple_domain
-    assert_equal '"TB"', diagram(:orientation => :vertical).graph[:rankdir].to_s
+    assert_equal '"LR"', diagram(:orientation => :vertical).graph[:rankdir].to_s
   end
 
   # Diagram generation =======================================================


### PR DESCRIPTION
## Summary
I had in my configuration file the option horizontal but was giving me vertical graphs and viceversa. I'm attaching all my files.

[erd.pdf](https://github.com/voormedia/rails-erd/files/86785/erd.pdf)
[erdconfig.txt](https://github.com/voormedia/rails-erd/files/86786/erdconfig.txt)
