### PR TITLE
Rescue from TypeError when loading target app

### DIFF
--- a/lib/rails_erd/cli.rb
+++ b/lib/rails_erd/cli.rb
@@ -152,6 +152,7 @@ module RailsERD
       # TODO: Add support for different kinds of environment.
       require "#{path}/config/environment"
       Rails.application.eager_load!
+    rescue TypeError
     end
 
     def create_diagram


### PR DESCRIPTION
When working on a large project that had legacy code in lib/ where
classes were inheriting from from Base or from ActiveRecord::Base but
instead were `class Foo < Struct.new` (a bad pattern) `eager_load!`s
behavior was causing classes to be reinstantiated and thus, due to the
behavior of `Struct.new` creating a new anonymous class with each call,
resulting in a TypeError. This will save us from those, at least.