### PR TITLE
support for 'only_models_include_depth' option

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,7 @@ warn: true
 title: sample title
 exclude: null
 only: null
+only_recursion_depth: null
 prepend_primary: false
 ```
 

--- a/examples/erdconfig.example
+++ b/examples/erdconfig.example
@@ -17,4 +17,5 @@ warn: true
 title: sample title
 exclude: null
 only: null
+only_recursion_depth: null
 prepend_primary: false

--- a/lib/rails_erd.rb
+++ b/lib/rails_erd.rb
@@ -52,6 +52,7 @@ module RailsERD
         :title, true,
         :exclude, nil,
         :only, nil,
+        :only_recursion_depth, nil,
         :prepend_primary, false
       ]
     end

--- a/lib/rails_erd/cli.rb
+++ b/lib/rails_erd/cli.rb
@@ -49,6 +49,11 @@ Choice.options do
     desc "Filter to only include listed models in diagram."
   end
 
+  option :only_recursion_depth do
+    long "--only_recursion_depth=INTEGER"
+    desc "Recurses into relations specified by --only upto a depth N."
+  end
+
   option :exclude do
     long "--exclude"
     desc "Filter to exclude listed models in diagram."


### PR DESCRIPTION
walks relationships and recurses them to a defined depth.
e.g. only_models_include_depth=2 includes associations up to 2 levels deep

I'm not so happy about the naming of the option. If you have anything better...

fixes #161