### PR TITLE
fix grouping of associations

### DIFF
--- a/lib/rails_erd/domain/relationship.rb
+++ b/lib/rails_erd/domain/relationship.rb
@@ -21,7 +21,7 @@ module RailsERD
         private
 
         def association_identity(association)
-          identifier = association_identifier(association)
+          identifier = association_identifier(association).to_s
           Set[identifier, association_owner(association), association_target(association)]
         end
 


### PR DESCRIPTION
identifier could be a symbol which led to double association_identies

fixes #70 