### PR TITLE
Revert "make RailsERD Engine"

### DIFF
--- a/lib/generators/erd/templates/auto_generate_diagram.rake
+++ b/lib/generators/erd/templates/auto_generate_diagram.rake
@@ -2,5 +2,5 @@
 # NOTE: are sensitive to local FS writes, and besides -- it's just not proper
 # NOTE: to have a dev-mode tool do its thing in production.
 if Rails.env.development?
-  RailsERD::Engine.load_tasks
+  Erd.load_tasks
 end

--- a/lib/rails_erd.rb
+++ b/lib/rails_erd.rb
@@ -1,6 +1,5 @@
 require "active_support/ordered_options"
 require "rails_erd/railtie" if defined? Rails
-require "rails_erd/engine" if defined? Rails
 require "rails_erd/config"
 
 # Welcome to the API documentation of Rails ERD. If you wish to extend or

--- a/lib/rails_erd/engine.rb
+++ b/lib/rails_erd/engine.rb
@@ -1,4 +1,0 @@
-module RailsERD
-  class Engine < ::Rails::Engine
-  end
-end


### PR DESCRIPTION
Reverts voormedia/rails-erd#176

The autogeneration needs a feature flipping environmental/config option. Until we get that, disabling.