### PR TITLE
Bump version number to 1.4.6 for release

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,9 @@
+1.4.6
+-----
+* Revert auto-generation of diagrams added in #176 (#191)
+* Fix some Ruby warnings (#187)
+* Rescue from TypeError when loading target app (#185)
+
 1.4.5
 -----
 

--- a/lib/rails_erd/version.rb
+++ b/lib/rails_erd/version.rb
@@ -1,4 +1,4 @@
 module RailsERD
-  VERSION = "1.4.5"
+  VERSION = "1.4.6"
   BANNER  = "RailsERD #{VERSION}"
 end


### PR DESCRIPTION
* Revert auto-generation of diagrams added in #176 (#191)
* Fix some Ruby warnings (#187)
* Rescue from TypeError when loading target app (#185)
