### PR TITLE
Updated diagram options (indirect -> direct)

### DIFF
--- a/customise.html
+++ b/customise.html
@@ -62,13 +62,13 @@ The following output options are available in Rails ERD.
     require Graphviz to be installed. Default value: <tt>pdf</tt>
   </dd>
 
-  <dt><pre>indirect               true | false</pre></dt>
+  <dt><pre>direct               true | false</pre></dt>
   <dd>
     Specifies whether or not to display relationships that are indirect.
     Indirect relationships are defined in Active Record by
     <tt>has_many :through</tt> associations. Older versions of Graphviz may
     have trouble drawing diagrams with indirect relationships.
-    Default value: <tt>true</tt>
+    Default value: <tt>false</tt>
   </dd>
 
   <dt><pre>inheritance            true | false</pre></dt>


### PR DESCRIPTION
Current documentation states "indirect" as an option, whereas the available option is called "direct"