### PR TITLE
Implement clustering by namespace

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,7 @@ title: sample title
 exclude: null
 only: null
 prepend_primary: false
+cluster: false
 ```
 
 

--- a/examples/erdconfig.example
+++ b/examples/erdconfig.example
@@ -18,3 +18,4 @@ title: sample title
 exclude: null
 only: null
 prepend_primary: false
+cluster: false

--- a/lib/rails_erd.rb
+++ b/lib/rails_erd.rb
@@ -51,7 +51,8 @@ module RailsERD
         :title, true,
         :exclude, nil,
         :only, nil,
-        :prepend_primary, false
+        :prepend_primary, false,
+        :cluster, false
       ]
     end
   end

--- a/lib/rails_erd/cli.rb
+++ b/lib/rails_erd/cli.rb
@@ -64,6 +64,11 @@ Choice.options do
     desc "Ensure primary key is at start of attribute list"
   end
 
+  option :cluster do
+    long "--cluster"
+    desc "Display models in subgraphs based on their namespace."
+  end
+
   separator ""
   separator "Output options:"
 

--- a/lib/rails_erd/config.rb
+++ b/lib/rails_erd/config.rb
@@ -63,8 +63,10 @@ module RailsERD
       # [<string>]
       when :only, :exclude
         Array(value).join(",").split(",").map { |v| v.strip }
+
       # true | false
-      when :disconnected, :indirect, :inheritance, :markup, :polymorphism, :warn
+      when :disconnected, :indirect, :inheritance, :markup, :polymorphism,
+           :warn, :cluster
         !!value
 
       # nil | <string>

--- a/lib/rails_erd/diagram/graphviz.rb
+++ b/lib/rails_erd/diagram/graphviz.rb
@@ -210,7 +210,14 @@ module RailsERD
       end
 
       each_entity do |entity, attributes|
-        draw_node entity.name, entity_options(entity, attributes)
+        if options[:cluster] && entity.namespace
+          cluster_name = "cluster_#{entity.namespace}"
+          cluster = graph.get_graph(cluster_name) ||
+                    graph.add_graph(cluster_name, label: entity.namespace)
+          draw_cluster_node cluster, entity.name, entity_options(entity, attributes)
+        else
+          draw_node entity.name, entity_options(entity, attributes)
+        end
       end
 
       each_specialization do |specialization|
@@ -233,15 +240,19 @@ module RailsERD
       private
 
       def node_exists?(name)
-        !!graph.get_node(escape_name(name))
+        !!graph.search_node(escape_name(name))
       end
 
       def draw_node(name, options)
         graph.add_nodes escape_name(name), options
       end
 
+      def draw_cluster_node(cluster, name, options)
+        cluster.add_nodes escape_name(name), options
+      end
+
       def draw_edge(from, to, options)
-        graph.add_edges graph.get_node(escape_name(from)), graph.get_node(escape_name(to)), options if node_exists?(from) and node_exists?(to)
+        graph.add_edges graph.search_node(escape_name(from)), graph.search_node(escape_name(to)), options if node_exists?(from) and node_exists?(to)
       end
 
       def escape_name(name)

--- a/lib/rails_erd/domain/entity.rb
+++ b/lib/rails_erd/domain/entity.rb
@@ -92,6 +92,10 @@ module RailsERD
         @children ||= domain.specializations_by_entity_name(name).map(&:specialized)
       end
 
+      def namespace
+        name.scan(/(.*)::.*/).dig(0,0)
+      end
+
       def to_s # @private :nodoc:
         name
       end


### PR DESCRIPTION
Resolves issue #156 

Enabling clustering will create subgraphs in graphviz. Clustering is based on the topmost namespace/module name.

### Example
With clustering enabled all Recipe::* models will all be sorted into a 'Recipe' cluster.
Please note, that this simply a made up example and not production app.

Without clustering:
![standard](https://cloud.githubusercontent.com/assets/1767130/15470290/245910d8-20f0-11e6-8744-b5b887966818.png)

With clustering:
![clustering](https://cloud.githubusercontent.com/assets/1767130/15470294/26657d3a-20f0-11e6-91a0-5394ee6efee0.png)