### PR TITLE
Add supports to non Rails apps.

### DIFF
--- a/lib/rails_erd/cli.rb
+++ b/lib/rails_erd/cli.rb
@@ -149,9 +149,14 @@ module RailsERD
 
     def load_application
       $stderr.puts "Loading application in '#{File.basename(path)}'..."
-      # TODO: Add support for different kinds of environment.
-      require "#{path}/config/environment"
-      Rails.application.eager_load!
+      begin
+        environment_path = "#{path}/config/environment.rb"
+        require environment_path
+      rescue ::LoadError
+        puts "Please create a file in '#{environment_path}' that loads your application environment."
+        raise
+      end
+      Rails.application.eager_load! if defined? Rails
     rescue TypeError
     end
 


### PR DESCRIPTION
Fixes #114 

I wanted to run ` bundle exec erd` on our Sinatra apps, with this patch all I had to do was create a `config/environment.rb` file that loaded my application environment (specially models) and the ERD output was successfully generated.

Thanks guys for the awesome project! 👍 