### PR TITLE
Fix deprecation of File.exists?

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Rails ERD - Generate Entity-Relationship Diagrams for Rails applications
 
 The second goal of Rails ERD is to provide you with a tool to inspect your application's domain model. If you don't like the default output, it is very easy to use the API to build your own diagrams.
 
-Rails ERD was created specifically for Rails and works on versions 3.0-4.2. It uses Active Record's built-in reflection capabilities to figure out how your models are associated.
+Rails ERD was created specifically for Rails and works on versions 3.0-5.0. It uses Active Record's built-in reflection capabilities to figure out how your models are associated.
 
 
 Preview

--- a/test/unit/graphviz_test.rb
+++ b/test/unit/graphviz_test.rb
@@ -137,7 +137,7 @@ class GraphvizTest < ActiveSupport::TestCase
 
   test "create should not create output if there are no connected models" do
     Diagram::Graphviz.create rescue nil
-    assert !File.exists?("erd.png")
+    assert !File.exist?("erd.png")
   end
 
   test "create should abort and complain if there are no connected models" do

--- a/test/unit/rake_task_test.rb
+++ b/test/unit/rake_task_test.rb
@@ -40,7 +40,7 @@ class RakeTaskTest < ActiveSupport::TestCase
 
   test "generate task should not create output if there are no connected models" do
     Rake::Task["erd:generate"].execute rescue nil
-    assert !File.exists?("erd.dot")
+    assert !File.exist?("erd.dot")
   end
 
   test "generate task should eager load application environment" do


### PR DESCRIPTION
`File.exists?` apparently was deprecated as of Ruby 2.1.