### PR TITLE
Avoid warnings when redefining methods in tests.

### DIFF
--- a/test/unit/attribute_test.rb
+++ b/test/unit/attribute_test.rb
@@ -4,6 +4,7 @@ require File.expand_path("../test_helper", File.dirname(__FILE__))
 class AttributeTest < ActiveSupport::TestCase
   def with_native_limit(type, new_limit)
     ActiveRecord::Base.connection.class_eval do
+      undef :native_database_types
       define_method :native_database_types do
         super().tap do |types|
           types[type][:limit] = new_limit
@@ -13,6 +14,7 @@ class AttributeTest < ActiveSupport::TestCase
     yield
   ensure
     ActiveRecord::Base.connection.class_eval do
+      undef :native_database_types
       define_method :native_database_types do
         super()
       end

--- a/test/unit/graphviz_test.rb
+++ b/test/unit/graphviz_test.rb
@@ -106,6 +106,7 @@ class GraphvizTest < ActiveSupport::TestCase
     begin
       GraphViz.class_eval do
         alias_method :old_output_and_errors_from_command, :output_and_errors_from_command
+        undef :output_and_errors_from_command
         def output_and_errors_from_command(*args); raise end
       end
       assert_nothing_raised do
@@ -113,6 +114,7 @@ class GraphvizTest < ActiveSupport::TestCase
       end
     ensure
       GraphViz.class_eval do
+        undef :output_and_errors_from_command
         alias_method :output_and_errors_from_command, :old_output_and_errors_from_command
       end
     end


### PR DESCRIPTION
Undef some methods before redefining, fixes a number of warnings when running the tests.