### PR TITLE
Avoid duplicate specializations when using STI with an abstract base class

### DIFF
--- a/lib/rails_erd/domain/specialization.rb
+++ b/lib/rails_erd/domain/specialization.rb
@@ -30,7 +30,7 @@ module RailsERD
         end
 
         def abstract_from_models(domain, models)
-          models.select(&:abstract_class?).collect(&:descendants).flatten.collect { |model|
+          models.select(&:abstract_class?).collect(&:direct_descendants).flatten.collect { |model|
             new(domain, domain.entity_by_name(model.superclass.name), domain.entity_by_name(model.name))
           }
         end

--- a/test/unit/attribute_test.rb
+++ b/test/unit/attribute_test.rb
@@ -4,6 +4,7 @@ require File.expand_path("../test_helper", File.dirname(__FILE__))
 class AttributeTest < ActiveSupport::TestCase
   def with_native_limit(type, new_limit)
     ActiveRecord::Base.connection.class_eval do
+      undef :native_database_types
       define_method :native_database_types do
         super().tap do |types|
           types[type][:limit] = new_limit
@@ -13,6 +14,7 @@ class AttributeTest < ActiveSupport::TestCase
     yield
   ensure
     ActiveRecord::Base.connection.class_eval do
+      undef :native_database_types
       define_method :native_database_types do
         super()
       end

--- a/test/unit/domain_test.rb
+++ b/test/unit/domain_test.rb
@@ -186,6 +186,15 @@ class DomainTest < ActiveSupport::TestCase
     assert_equal [Domain::Specialization] * 3, Domain.generate.specializations.collect(&:class)
   end
 
+  test "specializations should return specializations in domain model once for descendants of abstract class" do
+    create_model "Thing" do
+      self.abstract_class = true
+    end
+    create_model "Beverage", Thing, :type => :string
+    create_model "Beer", Beverage
+    assert_equal [Domain::Specialization], Domain.generate.specializations.collect(&:class)
+  end
+
   # Erroneous associations ===================================================
   test "relationships should omit bad has_many associations" do
     create_model "Foo" do

--- a/test/unit/graphviz_test.rb
+++ b/test/unit/graphviz_test.rb
@@ -106,6 +106,7 @@ class GraphvizTest < ActiveSupport::TestCase
     begin
       GraphViz.class_eval do
         alias_method :old_output_and_errors_from_command, :output_and_errors_from_command
+        undef :output_and_errors_from_command
         def output_and_errors_from_command(*args); raise end
       end
       assert_nothing_raised do
@@ -113,6 +114,7 @@ class GraphvizTest < ActiveSupport::TestCase
       end
     ensure
       GraphViz.class_eval do
+        undef :output_and_errors_from_command
         alias_method :output_and_errors_from_command, :old_output_and_errors_from_command
       end
     end


### PR DESCRIPTION
The specialisation edge is added twice if an STI base class inherits from an abstract class. For example:

`ApplicationRecord (abstract) -> Beverage (STI base) -> Beer -> (STI child)` causes the `Beverage -> Beer` specialisation to occur twice. This causes Graphviz to fail in confusion with the message:

> Error: in routesplines, cannot find NORMAL edge

This became a bigger issue with Rails 5, because the abstract base class `ApplicationRecord` is added by default.