### PR TITLE
Release 1.5.0

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,13 @@
+1.5.0
+-----
+* New option of 'clustering' by namespace (#205)
+* Support for 'only_models_include_depth' option (#219)
+* Added basic support for non-Rails apps (#208)
+* Avoid duplicate specializations when using STI with an abstract base class (#211)
+* Fixed Ruby 2.1 deprecation warnings (#209)
+* Fixes to tests (#210, #213)
+* Various documentation fixes (#203, #212)
+
 1.4.7
 -----
 * Fixed grouping of associations (#190)

--- a/lib/rails_erd/version.rb
+++ b/lib/rails_erd/version.rb
@@ -1,4 +1,4 @@
 module RailsERD
-  VERSION = "1.4.7"
+  VERSION = "1.5.0"
   BANNER  = "RailsERD #{VERSION}"
 end


### PR DESCRIPTION
Lots of new stuff in 1.5.0! We've gotten Rails 5.x support in place, as
well as adding 2 new options. "clustering" will draw a box around models
contained in the same name space, helping to visually organize areas of
concern. "only_models_include_depth" - although awkwardly named - will
restrict the depth of graphing to the supplied value.

* New option of 'clustering' by namespace (#205)
* Support for 'only_models_include_depth' option (#219)
* Added basic support for non-Rails apps (#208)
* Avoid duplicate specializations when using STI with an abstract base class (#211)
* Fixed Ruby 2.1 deprecation warnings (#209)
* Fixes to tests (#210, #213)
* Various documentation fixes (#203, #212)