### PR TITLE
Bump json gem to 1.8.3 so that gh-pages can be generated with ruby 2.2.x

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -74,7 +74,7 @@ GEM
       gemoji (~> 2.0)
       html-pipeline (~> 1.9)
       jekyll (~> 2.0)
-    json (1.8.1)
+    json (1.8.3)
     kramdown (1.3.1)
     liquid (2.6.1)
     listen (2.7.9)
@@ -113,3 +113,6 @@ PLATFORMS
 
 DEPENDENCIES
   github-pages (~> 23)
+
+BUNDLED WITH
+   1.12.5

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -98,7 +98,7 @@ GEM
       ffi (>= 0.5.0)
     rdiscount (2.1.7)
     redcarpet (3.1.2)
-    safe_yaml (1.0.3)
+    safe_yaml (1.0.4)
     sass (3.4.2)
     thread_safe (0.3.4)
     timers (1.1.0)


### PR DESCRIPTION
When installing the json gem with ruby 2.2.x, compilation fails. The
details of why it is failing are in this[0] github issue. Subsequent gem
releases (1.8.2+) have fixed the issue, so this commit bumps the gem to
the latest non-broken version so that people with ruby 2.2.x can install
and run the gh-pages for rails-erd locally.

[0] - https://github.com/flori/json/issues/229