### PR TITLE
Remove old 1.0 warning message as we're on 1.5 by now

### DIFF
--- a/customise.html
+++ b/customise.html
@@ -265,8 +265,3 @@ domain.relationships.first.mutual?
 domain.relationships.first.one_to_many?
 #=> true
 {% endhighlight %}
-
-<p>
-  Please note that before the 1.0 release, the API may change subtly between
-  minor versions.
-</p>


### PR DESCRIPTION
Brevity is the soul of wit and so too should our documentation be (at
least, in this case as it is just downright misleading).