### PR TITLE
eager load all the things to include models provided by engines

### DIFF
--- a/lib/rails_erd/cli.rb
+++ b/lib/rails_erd/cli.rb
@@ -166,7 +166,10 @@ module RailsERD
         puts "Please create a file in '#{environment_path}' that loads your application environment."
         raise
       end
-      Rails.application.eager_load! if defined? Rails
+      if defined? Rails
+        Rails.application.eager_load!
+        Rails.application.config.eager_load_namespaces.each(&:eager_load!)
+      end
     rescue TypeError
     end
 

--- a/lib/rails_erd/tasks.rake
+++ b/lib/rails_erd/tasks.rake
@@ -21,6 +21,7 @@ namespace :erd do
     say "Loading code in search of Active Record models..."
     begin
       Rails.application.eager_load!
+      Rails.application.config.eager_load_namespaces.each(&:eager_load!)
     rescue Exception => err
       if Rake.application.options.trace
         raise


### PR DESCRIPTION
Fixes https://github.com/voormedia/rails-erd/issues/3 (again), i.e. warnings like "Warning: Ignoring invalid association :whatever (model Whatever exists, but is not included in domain)"