### PR TITLE
Reduce noice in test output by fixing warnings

### DIFF
--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -150,7 +150,7 @@ class ActiveSupport::TestCase
         model.reset_column_information
         Object.send :remove_const, model.name.to_sym if Object.const_defined? model.name.to_sym
       end
-      ActiveRecord::Base.connection.tables.each do |table|
+      ActiveRecord::Base.connection.data_sources.each do |table|
         ActiveRecord::Base.connection.drop_table table
       end
       ActiveRecord::Base.direct_descendants.clear

--- a/test/unit/attribute_test.rb
+++ b/test/unit/attribute_test.rb
@@ -224,14 +224,14 @@ class AttributeTest < ActiveSupport::TestCase
   test "limit should return nil if there is no limit" do
     create_model "Foo"
     add_column :foos, :my_txt, :text
-    assert_equal nil, create_attribute(Foo, "my_txt").limit
+    assert_nil create_attribute(Foo, "my_txt").limit
   end
 
   test "limit should return nil if equal to standard database limit" do
     with_native_limit :string, 456 do
       create_model "Foo"
       add_column :foos, :my_str, :string, :limit => 456
-      assert_equal nil, create_attribute(Foo, "my_str").limit
+      assert_nil create_attribute(Foo, "my_str").limit
     end
   end
 
@@ -252,7 +252,7 @@ class AttributeTest < ActiveSupport::TestCase
   test "limit should return nil for decimal columns if equal to standard database limit" do
     create_model "Foo"
     add_column :foos, :num, :decimal
-    assert_equal nil, create_attribute(Foo, "num").limit
+    assert_nil create_attribute(Foo, "num").limit
   end
 
   test "limit should return nil if type is unsupported by rails" do
@@ -262,7 +262,7 @@ class AttributeTest < ActiveSupport::TestCase
         add_column "foos", "a", "REAL"
       end
     end
-    assert_equal nil, create_attribute(Foo, "a").limit
+    assert_nil create_attribute(Foo, "a").limit
   end
 
   test "limit should return nil for oddball column types that misuse the limit attribute" do
@@ -274,7 +274,7 @@ class AttributeTest < ActiveSupport::TestCase
         { :srid => 4326, :type => "point", :geographic => true }
       end
     end
-    assert_equal nil, attribute.limit
+    assert_nil attribute.limit
   end
 
   test "scale should return scale for decimal columns if nonstandard" do
@@ -286,7 +286,7 @@ class AttributeTest < ActiveSupport::TestCase
   test "scale should return nil for decimal columns if equal to standard database limit" do
     create_model "Foo"
     add_column :foos, :num, :decimal
-    assert_equal nil, create_attribute(Foo, "num").scale
+    assert_nil create_attribute(Foo, "num").scale
   end
 
   test "scale should return zero for decimal columns if left to default setting when specifying precision" do
@@ -302,7 +302,7 @@ class AttributeTest < ActiveSupport::TestCase
         add_column "foos", "a", "REAL"
       end
     end
-    assert_equal nil, create_attribute(Foo, "a").scale
+    assert_nil create_attribute(Foo, "a").scale
   end
 
   test "scale should return nil for oddball column types that misuse the scale attribute" do
@@ -313,6 +313,6 @@ class AttributeTest < ActiveSupport::TestCase
         1..5
       end
     end
-    assert_equal nil, attribute.scale
+    assert_nil attribute.scale
   end
 end

--- a/test/unit/domain_test.rb
+++ b/test/unit/domain_test.rb
@@ -28,7 +28,7 @@ class DomainTest < ActiveSupport::TestCase
       belongs_to :bar
     end
     create_model "Bar"
-    assert_match %r{#<RailsERD::Domain:.*>}, Domain.generate.inspect
+    assert_match(/#<RailsERD::Domain:.*>/, Domain.generate.inspect)
   end
 
   # Entity processing ========================================================
@@ -225,7 +225,7 @@ class DomainTest < ActiveSupport::TestCase
     output = collect_stdout do
       Domain.generate.relationships
     end
-    assert_match /Ignoring invalid association :flabs on Foo/, output
+    assert_match(/Ignoring invalid association :flabs on Foo/, output)
   end
 
   test "relationships should output a warning when an association to model outside domain is encountered" do
@@ -236,7 +236,7 @@ class DomainTest < ActiveSupport::TestCase
     output = collect_stdout do
       Domain.new([Foo]).relationships
     end
-    assert_match /model Bar exists, but is not included in domain/, output
+    assert_match(/model Bar exists, but is not included in domain/, output)
   end
 
   test "relationships should output a warning when an association to a non existent generalization is encountered" do
@@ -249,7 +249,7 @@ class DomainTest < ActiveSupport::TestCase
     output = collect_stdout do
       Domain.generate.relationships
     end
-    assert_match /polymorphic interface FooBar does not exist/, output
+    assert_match(/polymorphic interface FooBar does not exist/, output)
   end
 
   test "relationships should not warn when a bad association is encountered if warnings are disabled" do
@@ -273,6 +273,6 @@ class DomainTest < ActiveSupport::TestCase
     output = collect_stdout do
       Domain.generate.entities
     end
-    assert_match /Ignoring invalid model Foo \(table foos does not exist\)/, output
+    assert_match(/Ignoring invalid model Foo \(table foos does not exist\)/, output)
   end
 end

--- a/test/unit/graphviz_test.rb
+++ b/test/unit/graphviz_test.rb
@@ -149,7 +149,7 @@ class GraphvizTest < ActiveSupport::TestCase
     rescue => e
       message = e.message
     end
-    assert_match /No entities found/, message
+    assert_match(/No entities found/, message)
   end
 
   test "create should abort and complain if output directory does not exist" do
@@ -162,7 +162,7 @@ class GraphvizTest < ActiveSupport::TestCase
       message = e.message
     end
 
-    assert_match /Output directory 'does_not_exist' does not exist/, message
+    assert_match(/Output directory 'does_not_exist' does not exist/, message)
   end
 
   test "create should not fail when reserved words are used as node names" do

--- a/test/unit/rake_task_test.rb
+++ b/test/unit/rake_task_test.rb
@@ -100,7 +100,7 @@ class RakeTaskTest < ActiveSupport::TestCase
     rescue => e
       message = e.message
     end
-    assert_match /#{Regexp.escape(<<-MSG.strip).gsub("xxx", ".*?")}/, message
+    assert_match(/#{Regexp.escape(<<-MSG.strip).gsub("xxx", ".*?")}/, message)
 Loading models failed!
 Error occurred while loading application: FooBar (RuntimeError)
     test/unit/rake_task_test.rb:#{l1}:in `xxx'


### PR DESCRIPTION
When I run the tests against Rails 5.0.1 they produced hundreds of lines of warnings, making the test output very noisy.  Fix the following three types of warnings to make the test output readable again: 

- Fix Rails 5.0 deprecation warning for `#tables`
- Fix 'ambiguous first argument' warnings in `#assert_match` calls
- Fix Minitest warnings about using `#assert_nil`