### PR TITLE
remove dependency on ruby 2.3

### DIFF
--- a/lib/rails_erd/domain/entity.rb
+++ b/lib/rails_erd/domain/entity.rb
@@ -93,7 +93,7 @@ module RailsERD
       end
 
       def namespace
-        name.scan(/(.*)::.*/).dig(0,0)
+        name.scan(/(.*)::.*/).first.first
       end
 
       def to_s # @private :nodoc:


### PR DESCRIPTION
This small change allows this gem to run with rubies prior to 2.3. 
