### PR TITLE
Fix inner layout orientation in record templates

### DIFF
--- a/lib/rails_erd/diagram/templates/node.html.erb
+++ b/lib/rails_erd/diagram/templates/node.html.erb
@@ -1,4 +1,4 @@
-<% if options.orientation == :vertical %>{<% end %>
+<% if options.orientation == :horizontal %>{<% end %>
 <table border="0" align="center" cellspacing="0.5" cellpadding="0" width="<%= NODE_WIDTH + 4 %>">
   <tr><td align="center" valign="bottom" width="<%= NODE_WIDTH %>"><font face="<%= FONTS[:bold] %>" point-size="11"><%= entity.name %></font></td></tr>
 </table>
@@ -11,4 +11,4 @@
 </table>
 <% else %>
 <% end %>
-<% if options.orientation == :vertical %>}<% end %>
+<% if options.orientation == :horizontal %>}<% end %>

--- a/lib/rails_erd/diagram/templates/node.record.erb
+++ b/lib/rails_erd/diagram/templates/node.record.erb
@@ -1,4 +1,4 @@
-<% if options.orientation == :vertical %>{<% end %><%= entity.name %><% if attributes.any? %>
+<% if options.orientation == :horizontal %>{<% end %><%= entity.name %><% if attributes.any? %>
 |<%  attributes.each do |attribute| %><%=
        attribute %> (<%= attribute.type_description %>)
-<%   end %><% end %><% if options.orientation == :vertical %>}<% end %>
+<%   end %><% end %><% if options.orientation == :horizontal %>}<% end %>

--- a/test/unit/graphviz_test.rb
+++ b/test/unit/graphviz_test.rb
@@ -281,7 +281,7 @@ class GraphvizTest < ActiveSupport::TestCase
       belongs_to :author
     end
     create_model "Author", :name => :string
-    assert_match %r(\A"\{\w+|.*\}"\Z)m, find_dot_node(diagram(:orientation => :horizontal), "m_Author")[:label].to_gv
+    assert_match %r(\A"\{\w+\|.*\}"\Z)m, find_dot_node(diagram(:orientation => :horizontal), "m_Author")[:label].to_gv
   end
 
   test "node record labels should not have direction reversing braces for vertical orientation" do
@@ -290,7 +290,7 @@ class GraphvizTest < ActiveSupport::TestCase
       belongs_to :author
     end
     create_model "Author", :name => :string
-    assert_match %r(\A"\w+|.*"\Z)m, find_dot_node(diagram(:orientation => :vertical), "m_Author")[:label].to_gv
+    assert_match %r(\A"\w+\|.*"\Z)m, find_dot_node(diagram(:orientation => :vertical), "m_Author")[:label].to_gv
   end
 
   test "generate should create edge for each relationship" do

--- a/test/unit/graphviz_test.rb
+++ b/test/unit/graphviz_test.rb
@@ -228,7 +228,7 @@ class GraphvizTest < ActiveSupport::TestCase
       belongs_to :bar
     end
     create_model "Bar"
-    assert_equal %Q("Bar"), find_dot_node(diagram, "m_Bar")[:label].to_gv
+    assert_equal %Q("{Bar}"), find_dot_node(diagram, "m_Bar")[:label].to_gv
   end
 
   test "generate should add attributes to entity html labels" do
@@ -246,7 +246,7 @@ class GraphvizTest < ActiveSupport::TestCase
       belongs_to :bar
     end
     create_model "Bar", :column => :string, :column_two => :boolean
-    assert_equal %Q("Bar|column (string)\\ncolumn_two (boolean)\\n"), find_dot_node(diagram, "m_Bar")[:label].to_gv
+    assert_equal %Q("{Bar|column (string)\\ncolumn_two (boolean)\\n}"), find_dot_node(diagram, "m_Bar")[:label].to_gv
   end
 
   test "generate should not add any attributes to entity labels if attributes is set to false" do

--- a/test/unit/graphviz_test.rb
+++ b/test/unit/graphviz_test.rb
@@ -257,40 +257,40 @@ class GraphvizTest < ActiveSupport::TestCase
     assert_no_match %r{contents}, find_dot_node(diagram(:attributes => false), "m_Jar")[:label].to_gv
   end
 
-  test "node html labels should have direction reversing braces for vertical orientation" do
+  test "node html labels should have direction reversing braces for horizontal orientation" do
     RailsERD.options.markup = true
     create_model "Book", :author => :references do
       belongs_to :author
     end
     create_model "Author", :name => :string
-    assert_match %r(\A<\{\s*<.*\|.*>\s*\}>\Z)m, find_dot_node(diagram(:orientation => :vertical), "m_Author")[:label].to_gv
+    assert_match %r(\A<\{\s*<.*\|.*>\s*\}>\Z)m, find_dot_node(diagram(:orientation => :horizontal), "m_Author")[:label].to_gv
   end
 
-  test "node html labels should not have direction reversing braces for horizontal orientation" do
+  test "node html labels should not have direction reversing braces for vertical orientation" do
     RailsERD.options.markup = true
     create_model "Book", :author => :references do
       belongs_to :author
     end
     create_model "Author", :name => :string
-    assert_match %r(\A<\s*<.*\|.*>\s*>\Z)m, find_dot_node(diagram(:orientation => :horizontal), "m_Author")[:label].to_gv
+    assert_match %r(\A<\s*<.*\|.*>\s*>\Z)m, find_dot_node(diagram(:orientation => :vertical), "m_Author")[:label].to_gv
   end
 
-  test "node record labels should have direction reversing braces for vertical orientation" do
+  test "node record labels should have direction reversing braces for horizontal orientation" do
     RailsERD.options.markup = false
     create_model "Book", :author => :references do
       belongs_to :author
     end
     create_model "Author", :name => :string
-    assert_match %r(\A"\{\w+|.*\}"\Z)m, find_dot_node(diagram(:orientation => :vertical), "m_Author")[:label].to_gv
+    assert_match %r(\A"\{\w+|.*\}"\Z)m, find_dot_node(diagram(:orientation => :horizontal), "m_Author")[:label].to_gv
   end
 
-  test "node record labels should not have direction reversing braces for horizontal orientation" do
+  test "node record labels should not have direction reversing braces for vertical orientation" do
     RailsERD.options.markup = false
     create_model "Book", :author => :references do
       belongs_to :author
     end
     create_model "Author", :name => :string
-    assert_match %r(\A"\w+|.*"\Z)m, find_dot_node(diagram(:orientation => :horizontal), "m_Author")[:label].to_gv
+    assert_match %r(\A"\w+|.*"\Z)m, find_dot_node(diagram(:orientation => :vertical), "m_Author")[:label].to_gv
   end
 
   test "generate should create edge for each relationship" do


### PR DESCRIPTION
- [x] **Invert horizontal and vertical orientations in tests**

    Four tests where forgotten in PR #183, where the meaning of the horizontal and vertical orientation options where swapped. Inverting the tests uncovered that one test, `"node record labels should not have direction reversing braces for horizontal orientation"`, did not actually test what it says because the regular expression used had an issue. 

- [x] **Fix too broad regular expression in test matching almost everything by escaping the literal pipe character `|`**

    The pipe character, when not escaped, is used in regular expressions to enumerate alternatives. The regex `/cat|dog/` matches both the string `"cat"` as well as the string `"dog"`.

    The regex with the unescaped pipe character in the test `"node record labels should not have direction reversing braces for horizontal orientation"` matches any string that ends with a double quotation mark `"` and does not actually test whether the test input contains braces.

- [x] **Fix usage of orientation option in record templates**
   
    Depending on the graphs orientation, record nodes need to be wrapped in curly braces `{ }` so that the inner layout orientation of the record is always top-to-bottom and does not change with the global graph orientation.
Since #183 swapped the meaning of the `:vertical` and `:horizontal` orientation options, the templates need to be changed accordingly. This closes #218.

- [x] **Fix tests that now require direction reversing braces in regex**

    Since the horizontal graph orientation is the default and the templates insert direction reversing braces around records in this orientation, some regular expressions in tests need to be adjusted accordingly.
