### PR TITLE
Allow user to specify splines type in options

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,7 @@ only: null
 only_recursion_depth: null
 prepend_primary: false
 cluster: false
+splines: spline
 ```
 
 

--- a/lib/rails_erd/cli.rb
+++ b/lib/rails_erd/cli.rb
@@ -74,6 +74,11 @@ Choice.options do
     desc "Display models in subgraphs based on their namespace."
   end
 
+  option :splines do
+    long "--splines=SPLINE_TYPE"
+    desc "Control how edges are represented. See http://www.graphviz.org/doc/info/attrs.html#d:splines for values."
+  end
+
   separator ""
   separator "Output options:"
 

--- a/lib/rails_erd/diagram/graphviz.rb
+++ b/lib/rails_erd/diagram/graphviz.rb
@@ -188,6 +188,9 @@ module RailsERD
         # Title of the graph itself.
         graph[:label] = "#{title}\\n\\n" if title
 
+        # Style of splines
+        graph[:splines] = options.splines
+
         # Setup notation options.
         extend self.class.const_get(options.notation.to_s.capitalize.to_sym)
       end

--- a/lib/rails_erd/diagram/graphviz.rb
+++ b/lib/rails_erd/diagram/graphviz.rb
@@ -62,7 +62,8 @@ module RailsERD
         concentrate: true,
         labelloc:    :t,
         fontsize:    13,
-        fontname:    FONTS[:bold]
+        fontname:    FONTS[:bold],
+        splines:     'spline'
       }
 
       # Default node attributes.
@@ -189,7 +190,10 @@ module RailsERD
         graph[:label] = "#{title}\\n\\n" if title
 
         # Style of splines
-        graph[:splines] = options.splines
+        graph[:splines] = options.splines unless options.splines.nil?
+
+        # Shape of nodes
+        graph.node[:shape] = options.node_shape if options.node_shape
 
         # Setup notation options.
         extend self.class.const_get(options.notation.to_s.capitalize.to_sym)

--- a/lib/rails_erd/diagram/graphviz.rb
+++ b/lib/rails_erd/diagram/graphviz.rb
@@ -192,9 +192,6 @@ module RailsERD
         # Style of splines
         graph[:splines] = options.splines unless options.splines.nil?
 
-        # Shape of nodes
-        graph.node[:shape] = options.node_shape if options.node_shape
-
         # Setup notation options.
         extend self.class.const_get(options.notation.to_s.capitalize.to_sym)
       end

--- a/test/unit/graphviz_test.rb
+++ b/test/unit/graphviz_test.rb
@@ -186,6 +186,16 @@ class GraphvizTest < ActiveSupport::TestCase
     assert_equal '"Domain model\n\n"', diagram.graph.graph[:label].to_s
   end
 
+  test "generate should add default value for splines attribute" do
+    create_simple_domain
+    assert_equal '"spline"', diagram.graph.graph[:splines].to_s
+  end
+
+  test "generate should add set value for splines attribute" do
+    create_simple_domain
+    assert_equal '"ortho"', diagram(splines: 'ortho').graph.graph[:splines].to_s
+  end
+
   test "generate should add title with application name to graph" do
     begin
       Object::Quux = Module.new


### PR DESCRIPTION
I've allowed the user to specify the splines type in options. I did this so I could set it to "ortho" as I think it's quite neat. Attribute reference here: http://www.graphviz.org/doc/info/attrs.html#d:splines.

On another note, I wanted to be able to have a vertical node layout (i.e. heading at the top and attributes underneath) without changing the rank direction of the overall graph but couldn't find a neat solution. Any suggestions?

Thanks