### PR TITLE
Update GitHub pages links to HTTPS

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,14 +1,14 @@
 Install & Run
 -------
 
-The site uses [Jekyll](http://jekyllrb.com/docs/home/) to generate the content.
+The site uses [Jekyll](https://jekyllrb.com/docs/home/) to generate the content.
 The necessary dependencies are installed with `bundle install`.
 
 Start Jekyll with `bundle exec jekyll serve -w` and view the results in browser at
 `http://localhost:4000/rails-erd/`.
 
 More details about how to use Jekyll with Github Pages at
-https://help.github.com/articles/using-jekyll-with-pages and http://jekyllrb.com/docs/github-pages/
+https://help.github.com/articles/using-jekyll-as-a-static-site-generator-with-github-pages/ and https://jekyllrb.com/docs/github-pages/
 
 
 License
@@ -17,7 +17,7 @@ License
 Copyright 2010-2013, Voormedia - www.voormedia.com
 
 This directory contains the skeleton of the website of Rails ERD as it is hosted
-at http://voormedia.github.io/rails-erd. The written text in this directory is
+at https://voormedia.github.io/rails-erd/. The written text in this directory is
 considered part of the documentation and is therefore licensed under the same
 terms as the software itself (see LICENSE).
 

--- a/_includes/navigation.html
+++ b/_includes/navigation.html
@@ -6,7 +6,7 @@
       <li><a {% if page.id == "install" %}class="selected" {% endif %}href="{{site.baseurl}}/install.html">Install</a></li>
       <li><a {% if page.id == "customise" %}class="selected" {% endif %}href="{{site.baseurl}}/customise.html">Customise</a></li>
       <li><a href="{{site.docurl}}">API Docs</a></li>
-      <li><a href="http://github.com/voormedia/rails-erd">Source</a></li>
+      <li><a href="https://github.com/voormedia/rails-erd">Source</a></li>
     </ul>
   </div>
 </div>

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -1,5 +1,5 @@
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
-<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "https://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
+<html xmlns="https://www.w3.org/1999/xhtml/" xml:lang="en" lang="en">
   <head>
     <title>Rails ERD – {{page.title}}</title>
     <meta http-equiv="imagetoolbar" content="no"/>

--- a/customise.html
+++ b/customise.html
@@ -151,7 +151,7 @@ The following output options are available in Rails ERD.
 <p>
   Rails ERD provides an abstract class that you can use to implement your
   own diagram generation code. The following example generates code that can be
-  used with <a href="http://yuml.me/">yUML</a>, an online UML diagram service...
+  used with <a href="https://yuml.me/">yUML</a>, an online UML diagram service...
 </p>
 
 {% highlight ruby %}
@@ -196,8 +196,8 @@ YumlDiagram.create
 {% endhighlight %}
 
 <p>
-  You can paste the resulting code at <a href="http://yuml.me/">yuml.me</a> to
-  generate a diagram. <a href="http://yuml.me/diagram/scruffy/class/%5BRubygem%5D%201-*%3E%20%5BOwnership%5D,%20%5BRubygem%5D%201-*%3E%20%5BSubscription%5D,%20%5BRubygem%5D%201-*%3E%20%5BVersion%5D,%20%5BRubygem%5D%201-1%3E%20%5BLinkset%5D,%20%5BRubygem%5D%201-*%3E%20%5BDependency%5D,%20%5BVersion%5D%201-*%3E%20%5BDependency%5D,%20%5BUser%5D%201-*%3E%20%5BOwnership%5D,%20%5BUser%5D%201-*%3E%20%5BSubscription%5D,%20%5BUser%5D%201-*%3E%20%5BWebHook%5D">Here's an example</a>.
+  You can paste the resulting code at <a href="https://yuml.me/">yuml.me</a> to
+  generate a diagram. <a href="https://yuml.me/diagram/scruffy/class/%5BRubygem%5D%201-*%3E%20%5BOwnership%5D,%20%5BRubygem%5D%201-*%3E%20%5BSubscription%5D,%20%5BRubygem%5D%201-*%3E%20%5BVersion%5D,%20%5BRubygem%5D%201-1%3E%20%5BLinkset%5D,%20%5BRubygem%5D%201-*%3E%20%5BDependency%5D,%20%5BVersion%5D%201-*%3E%20%5BDependency%5D,%20%5BUser%5D%201-*%3E%20%5BOwnership%5D,%20%5BUser%5D%201-*%3E%20%5BSubscription%5D,%20%5BUser%5D%201-*%3E%20%5BWebHook%5D">Here's an example</a>.
 </p>
 
 <h2><a name="api">Domain model API</a></h2>

--- a/gallery.html
+++ b/gallery.html
@@ -27,9 +27,9 @@ title: Gallery of example diagrams
 </p>
 <p><img src="{{site.baseurl}}/images/gemcutter.png" class="erd" alt="Gemcutter entity-relationship diagram"/></p>
 
-<h2><a name="spree">Typo</a></h2>
+<h2><a name="publify">Publify</a></h2>
 <p>
-  Some models rely heavily on single table inheritance. <a href="http://github.com/fdv/typo/wiki">Typo</a>, a
+  Some models rely heavily on single table inheritance. <a href="https://github.com/publify/publify/wiki">Publify</a>, a
   popular blogging application, uses single table inheritance for many of its
   most important models. To explicitly display all child models and their
   relationships, this diagram was generated with <tt>inheritance=true</tt>.

--- a/gallery.html
+++ b/gallery.html
@@ -21,7 +21,7 @@ title: Gallery of example diagrams
 
 <h2><a name="gemcutter">Gemcutter</a></h2>
 <p>
-  The Rubygems website is powered by <a href="http://rubygems.org/">Gemcutter</a>.
+  The Rubygems website is powered by <a href="https://rubygems.org/">Gemcutter</a>.
   This application maintains an overview of all available Ruby libraries that
   are packaged as gems.
 </p>
@@ -39,7 +39,7 @@ title: Gallery of example diagrams
 <h2><a name="spree">Spree</a></h2>
 <p>
   Slightly larger domain models may be difficult to comprehend, even when drawn
-  in a diagram. <a href="http://spreecommerce.com/">Spree</a> is an open-source
+  in a diagram. <a href="https://spreecommerce.com/">Spree</a> is an open-source
   e-commerce application with 60 models. If we hide the attributes,
   the diagram gives a clearer overview of the entities themselves. This diagram
   was generated with <tt>attributes=false</tt>.

--- a/install.html
+++ b/install.html
@@ -98,7 +98,7 @@ RailsERD::Diagram::Graphviz.create
 </p>
 <p>
   If things are still not running smoothly, I'd love to hear from you.
-  You can either create a <a href="http://github.com/voormedia/rails-erd/issues">new issue</a>,
+  You can either create a <a href="https://github.com/voormedia/rails-erd/issues">new issue</a>,
   or drop me a line at <b>r.timmermans <em>at</em> voormedia.com</b>. If
   something goes wrong while generating a diagram, please provide a set of
   example models that exhibit the problem.


### PR DESCRIPTION
The link at the top of the repository can also be updated to HTTPS but I have no control over that.