### PR TITLE
Add erd:check_dependencies rake task to verify GraphViz is installed

### DIFF
--- a/lib/rails_erd/tasks.rake
+++ b/lib/rails_erd/tasks.rake
@@ -1,8 +1,18 @@
+require 'graphviz/utils'
+
 def say(message)
   puts message unless Rake.application.options.silent
 end
 
 namespace :erd do
+  task :check_dependencies do
+    include GraphViz::Utils
+    unless find_executable("dot", nil)
+      raise "Unable to find GraphViz's \"dot\" executable. Please " \
+            "visit https://voormedia.github.io/rails-erd/install.html for installation instructions."
+    end
+  end
+
   task :options do
     (RailsERD.options.keys.map(&:to_s) & ENV.keys).each do |option|
       RailsERD.options[option.to_sym] = case ENV[option]
@@ -34,7 +44,7 @@ namespace :erd do
     raise "Active Record was not loaded." unless defined? ActiveRecord
   end
 
-  task :generate => [:options, :load_models] do
+  task :generate => [:check_dependencies, :options, :load_models] do
     say "Generating Entity-Relationship Diagram for #{ActiveRecord::Base.descendants.length} models..."
 
     require "rails_erd/diagram/graphviz"


### PR DESCRIPTION
This adds an "erb:check_depencencies" rake task verify GraphViz is installed. If it isn't, the user is given a link to the installation instructions on the website.