### PR TITLE
Fix warnings when running tests against Rails 5.0.x

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,7 @@ gemfile:
   - gemfiles/Gemfile-rails.4.0.x
   - gemfiles/Gemfile-rails.4.1.x
   - gemfiles/Gemfile-rails.4.2.x
+  - gemfiles/Gemfile-rails.5.0.x
   - gemfiles/Gemfile-rails.edge
 before_install:
   - gem install bundler
@@ -17,6 +18,13 @@ before_install:
   - sudo apt-get install -qq graphviz
 script: bundle exec rake
 matrix:
+  exclude:
+    - rvm: 1.9.3
+      gemfile: gemfiles/Gemfile-rails.5.0.x
+    - rvm: 2.0
+      gemfile: gemfiles/Gemfile-rails.5.0.x
+    - rvm: 2.1
+      gemfile: gemfiles/Gemfile-rails.5.0.x
   allow_failures:
     - rvm: jruby
     - gemfile: gemfiles/Gemfile-rails.edge

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Requirements
 ---------------
 
 * Ruby 1.9.3+
-* ActiveRecord 3.x
+* ActiveRecord 3.x - 5.0.x
 
 Getting started
 ---------------
@@ -41,7 +41,7 @@ See the [installation instructions](https://voormedia.github.io/rails-erd/instal
 
 Rails ERD has the ability to be configured via the command line or through the use of a YAML file with configuration options set. It will look for this file first at `~/.erdconfig` and then `./.erdconfig` (which will override any settings in `~/.erdconfig`). The format of the file is as follows (shown here with the default settings used if no `.erdconfig` is found). More information on [customization options](https://voormedia.github.io/rails-erd/customise.html) can be found in Rails ERD's project documentation.
 
-```
+```yaml
 attributes:
   - content
   - foreign_key

--- a/gemfiles/Gemfile-rails.5.0.x
+++ b/gemfiles/Gemfile-rails.5.0.x
@@ -1,0 +1,21 @@
+source "http://rubygems.org"
+
+gemspec :path => ".."
+
+gem "activerecord", "~> 5.0.2"
+
+group :development do
+  gem 'mocha'
+  gem "rake"
+  gem "yard"
+
+  platforms :ruby do
+    gem "sqlite3"
+    gem "redcarpet"
+  end
+
+  platforms :jruby do
+    gem "activerecord-jdbcsqlite3-adapter"
+    gem "jruby-openssl", :require => false # Silence openssl warnings.
+  end
+end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -150,12 +150,20 @@ class ActiveSupport::TestCase
         model.reset_column_information
         Object.send :remove_const, model.name.to_sym if Object.const_defined? model.name.to_sym
       end
-      ActiveRecord::Base.connection.tables.each do |table|
+      tables_and_views.each do |table|
         ActiveRecord::Base.connection.drop_table table
       end
       ActiveRecord::Base.direct_descendants.clear
       ActiveSupport::Dependencies::Reference.clear!
       ActiveRecord::Base.clear_cache!
+    end
+  end
+
+  def tables_and_views
+    if ActiveRecord::VERSION::MAJOR >= 5
+      ActiveRecord::Base.connection.data_sources
+    else
+      ActiveRecord::Base.connection.tables
     end
   end
 end

--- a/test/unit/attribute_test.rb
+++ b/test/unit/attribute_test.rb
@@ -224,14 +224,14 @@ class AttributeTest < ActiveSupport::TestCase
   test "limit should return nil if there is no limit" do
     create_model "Foo"
     add_column :foos, :my_txt, :text
-    assert_equal nil, create_attribute(Foo, "my_txt").limit
+    assert_nil create_attribute(Foo, "my_txt").limit
   end
 
   test "limit should return nil if equal to standard database limit" do
     with_native_limit :string, 456 do
       create_model "Foo"
       add_column :foos, :my_str, :string, :limit => 456
-      assert_equal nil, create_attribute(Foo, "my_str").limit
+      assert_nil create_attribute(Foo, "my_str").limit
     end
   end
 
@@ -252,7 +252,7 @@ class AttributeTest < ActiveSupport::TestCase
   test "limit should return nil for decimal columns if equal to standard database limit" do
     create_model "Foo"
     add_column :foos, :num, :decimal
-    assert_equal nil, create_attribute(Foo, "num").limit
+    assert_nil create_attribute(Foo, "num").limit
   end
 
   test "limit should return nil if type is unsupported by rails" do
@@ -262,7 +262,7 @@ class AttributeTest < ActiveSupport::TestCase
         add_column "foos", "a", "REAL"
       end
     end
-    assert_equal nil, create_attribute(Foo, "a").limit
+    assert_nil create_attribute(Foo, "a").limit
   end
 
   test "limit should return nil for oddball column types that misuse the limit attribute" do
@@ -274,7 +274,7 @@ class AttributeTest < ActiveSupport::TestCase
         { :srid => 4326, :type => "point", :geographic => true }
       end
     end
-    assert_equal nil, attribute.limit
+    assert_nil attribute.limit
   end
 
   test "scale should return scale for decimal columns if nonstandard" do
@@ -286,7 +286,7 @@ class AttributeTest < ActiveSupport::TestCase
   test "scale should return nil for decimal columns if equal to standard database limit" do
     create_model "Foo"
     add_column :foos, :num, :decimal
-    assert_equal nil, create_attribute(Foo, "num").scale
+    assert_nil create_attribute(Foo, "num").scale
   end
 
   test "scale should return zero for decimal columns if left to default setting when specifying precision" do
@@ -302,7 +302,7 @@ class AttributeTest < ActiveSupport::TestCase
         add_column "foos", "a", "REAL"
       end
     end
-    assert_equal nil, create_attribute(Foo, "a").scale
+    assert_nil create_attribute(Foo, "a").scale
   end
 
   test "scale should return nil for oddball column types that misuse the scale attribute" do
@@ -313,6 +313,6 @@ class AttributeTest < ActiveSupport::TestCase
         1..5
       end
     end
-    assert_equal nil, attribute.scale
+    assert_nil attribute.scale
   end
 end

--- a/test/unit/domain_test.rb
+++ b/test/unit/domain_test.rb
@@ -225,7 +225,7 @@ class DomainTest < ActiveSupport::TestCase
     output = collect_stdout do
       Domain.generate.relationships
     end
-    assert_match /Ignoring invalid association :flabs on Foo/, output
+    assert_match(/Ignoring invalid association :flabs on Foo/, output)
   end
 
   test "relationships should output a warning when an association to model outside domain is encountered" do
@@ -236,7 +236,7 @@ class DomainTest < ActiveSupport::TestCase
     output = collect_stdout do
       Domain.new([Foo]).relationships
     end
-    assert_match /model Bar exists, but is not included in domain/, output
+    assert_match(/model Bar exists, but is not included in domain/, output)
   end
 
   test "relationships should output a warning when an association to a non existent generalization is encountered" do
@@ -249,7 +249,7 @@ class DomainTest < ActiveSupport::TestCase
     output = collect_stdout do
       Domain.generate.relationships
     end
-    assert_match /polymorphic interface FooBar does not exist/, output
+    assert_match(/polymorphic interface FooBar does not exist/, output)
   end
 
   test "relationships should not warn when a bad association is encountered if warnings are disabled" do
@@ -273,6 +273,6 @@ class DomainTest < ActiveSupport::TestCase
     output = collect_stdout do
       Domain.generate.entities
     end
-    assert_match /Ignoring invalid model Foo \(table foos does not exist\)/, output
+    assert_match(/Ignoring invalid model Foo \(table foos does not exist\)/, output)
   end
 end

--- a/test/unit/graphviz_test.rb
+++ b/test/unit/graphviz_test.rb
@@ -149,7 +149,7 @@ class GraphvizTest < ActiveSupport::TestCase
     rescue => e
       message = e.message
     end
-    assert_match /No entities found/, message
+    assert_match(/No entities found/, message)
   end
 
   test "create should abort and complain if output directory does not exist" do
@@ -162,7 +162,7 @@ class GraphvizTest < ActiveSupport::TestCase
       message = e.message
     end
 
-    assert_match /Output directory 'does_not_exist' does not exist/, message
+    assert_match(/Output directory 'does_not_exist' does not exist/, message)
   end
 
   test "create should not fail when reserved words are used as node names" do

--- a/test/unit/rake_task_test.rb
+++ b/test/unit/rake_task_test.rb
@@ -100,12 +100,13 @@ class RakeTaskTest < ActiveSupport::TestCase
     rescue => e
       message = e.message
     end
-    assert_match /#{Regexp.escape(<<-MSG.strip).gsub("xxx", ".*?")}/, message
+    assert_match(/#{Regexp.escape(<<-MSG.strip).gsub("xxx", ".*?")}/, message
 Loading models failed!
 Error occurred while loading application: FooBar (RuntimeError)
     test/unit/rake_task_test.rb:#{l1}:in `xxx'
     test/unit/rake_task_test.rb:#{l2}:in `xxx'
     MSG
+    )
   end
 
   test "generate task should reraise if application could not be loaded and trace option is enabled" do


### PR DESCRIPTION
This adds Rails 5.0.x to the test matrix and resolves the warnings when running against that version range (currently 5.0.2). Note that this does not fix the warnings in #249 (shown at https://travis-ci.org/voormedia/rails-erd/jobs/151324467).

These are the warnings that are resolved:
```
/home/rails/rails-erd/test/unit/domain_test.rb:228: warning: ambiguous first argument; put parentheses or a space even after `/' operator
```
```
Use assert_nil if expecting nil from /home/rails/rails-erd/test/unit/attribute_test.rb:277:in `block in <class:AttributeTest>'. This will fail in MT6.
```
```
DEPRECATION WARNING: #tables currently returns both tables and views. This behavior is deprecated and will be changed with Rails 5.1 to only return tables. Use #data_sources instead. (called from reset_domain at /home/rails/rails-erd/test/test_helper.rb:153)
```