### PR TITLE
Fix only flag to work 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ rdoc
 site/_generated
 Gemfile.lock
 gemfiles/*.lock
+.idea/

--- a/lib/rails_erd/diagram.rb
+++ b/lib/rails_erd/diagram.rb
@@ -124,13 +124,12 @@ module RailsERD
     # internally by Diagram#create.
     def generate
       instance_eval(&callbacks[:setup])
-
       if options.only_recursion_depth.present?
         depth = options.only_recursion_depth.to_i
-        options.only.dup.each do |class_name|
-          options.only += recurse_into_relationships(@domain.entity_by_name(class_name), depth)
+        options[:only].dup.each do |class_name|
+          options[:only]+= recurse_into_relationships(@domain.entity_by_name(class_name), depth)
         end
-        options.only.uniq!
+        options[:only].uniq!
       end
 
       filtered_entities.each do |entity|
@@ -179,7 +178,7 @@ module RailsERD
     def filtered_entities
       @domain.entities.reject { |entity|
         options.exclude.present? && entity.model && [options.exclude].flatten.map(&:to_sym).include?(entity.name.to_sym) or
-        options.only.present? && entity.model && ![options.only].flatten.map(&:to_sym).include?(entity.name.to_sym) or
+        options[:only].present? && entity.model && ![options[:only]].flatten.map(&:to_sym).include?(entity.name.to_sym) or
         !options.inheritance && entity.specialized? or
         !options.polymorphism && entity.generalized? or
         !options.disconnected && entity.disconnected?


### PR DESCRIPTION
I noted the `only` flag was not being respected.

This was because `.only` is a method inherited from `Hash` on `ActiveSupport::OrderedOptions` therefore it was always returning an empty `{}`.

A long term solution may be to change the option name to avoid using a loaded term, this fix simply changes the access method to use the traditional `Hash` accessor `[]`