### PR TITLE
eager load all the things to include models provided by engines take 2

### DIFF
--- a/lib/rails_erd/cli.rb
+++ b/lib/rails_erd/cli.rb
@@ -171,7 +171,10 @@ module RailsERD
         puts "Please create a file in '#{environment_path}' that loads your application environment."
         raise
       end
-      Rails.application.eager_load! if defined? Rails
+      if defined? Rails
+        Rails.application.eager_load!
+        Rails.application.config.eager_load_namespaces.each(&:eager_load!)
+      end
     rescue TypeError
     end
 

--- a/lib/rails_erd/tasks.rake
+++ b/lib/rails_erd/tasks.rake
@@ -31,6 +31,7 @@ namespace :erd do
     say "Loading code in search of Active Record models..."
     begin
       Rails.application.eager_load!
+      Rails.application.config.eager_load_namespaces.each(&:eager_load!)
     rescue Exception => err
       if Rake.application.options.trace
         raise

--- a/lib/rails_erd/tasks.rake
+++ b/lib/rails_erd/tasks.rake
@@ -31,7 +31,10 @@ namespace :erd do
     say "Loading code in search of Active Record models..."
     begin
       Rails.application.eager_load!
-      Rails.application.config.eager_load_namespaces.each(&:eager_load!)
+
+      if Rails.application.respond_to?(:config) && !Rails.application.config.nil?
+        Rails.application.config.eager_load_namespaces.each(&:eager_load!)
+      end
     rescue Exception => err
       if Rake.application.options.trace
         raise

--- a/test/unit/rake_task_test.rb
+++ b/test/unit/rake_task_test.rb
@@ -20,6 +20,7 @@ class RakeTaskTest < ActiveSupport::TestCase
     Object::Quux = Module.new
     Object::Quux::Application = Class.new
     Object::Rails = Struct.new(:application).new(Object::Quux::Application.new)
+
     Rails.class_eval do
       define_method :backtrace_cleaner do
         ActiveSupport::BacktraceCleaner.new.tap do |cleaner|


### PR DESCRIPTION
Working off of #233 which attempted to solve #3 once and for all.. tests on #233 were failing due to undefined `config` method on Rails app being manually built in test. That's not a great situation, but adding a couple guard clauses fixes the issue neatly enough.