### PR TITLE
Release v1.5.1

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,16 @@
+1.5.1
+-----
+* Improved < Ruby 2.3 support (#239)
+* Squashed once and for all the horizontal vs vertical orientation bugs (#241)
+* Added option for specifying spline types (#242)
+* Added a check for Graphviz installation before building out object graph (#248)
+* Fixed a bug in auto-generation rake task (#252)
+* `--cluster` option will work more reliably now! (#253)
+* Because it is 2017, we added Rails 5 to our official test matrix (#254)
+* Fixed a bug in `--only` that prevented it from working reliably (#257)
+* Added eager loading across all namespaces in the app (#258)
+* Minor improvements to tests (#228)
+
 1.5.0
 -----
 * New option of 'clustering' by namespace (#205)

--- a/lib/rails_erd/version.rb
+++ b/lib/rails_erd/version.rb
@@ -1,4 +1,4 @@
 module RailsERD
-  VERSION = "1.5.0"
+  VERSION = "1.5.1"
   BANNER  = "RailsERD #{VERSION}"
 end

--- a/rails-erd.gemspec
+++ b/rails-erd.gemspec
@@ -4,8 +4,8 @@ require "rails_erd/version"
 Gem::Specification.new do |s|
   s.name        = "rails-erd"
   s.version     = RailsERD::VERSION
-  s.authors     = ["Rolf Timmermans"]
-  s.email       = ["r.timmermans@voormedia.com"]
+  s.authors     = ["Rolf Timmermans", "Kerri Miller"]
+  s.email       = ["r.timmermans@voormedia.com", "kerrizor@kerrizor.com"]
   s.homepage    = "https://github.com/voormedia/rails-erd"
   s.summary     = "Entity-relationship diagram for your Rails models."
   s.description = "Automatically generate an entity-relationship diagram (ERD) for your Rails models."


### PR DESCRIPTION
Another big point release!

* Improved < Ruby 2.3 support (#239)
* Squashed once and for all the horizontal vs vertical orientation bugs (#241)
* Added option for specifying spline types (#242)
* Added a check for Graphviz installation before building out object graph (#248)
* Fixed a bug in auto-generation rake task (#252)
* `--cluster` option will work more reliably now! (#253)
* Because it is 2017, we added Rails 5 to our official test matrix (#254)
* Fixed a bug in `--only` that prevented it from working reliably (#257)
* Added eager loading across all namespaces in the app (#258)
* Minor improvements to tests (#228)