### PR TITLE
v1.5.2

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,10 @@
+1.5.2
+-----
+  * Disable calls to `eager_load_namespaces` < Rails 5 (#263)
+
 1.5.1
 -----
+
 * Improved < Ruby 2.3 support (#239)
 * Squashed once and for all the horizontal vs vertical orientation bugs (#241)
 * Added option for specifying spline types (#242)

--- a/lib/rails_erd/version.rb
+++ b/lib/rails_erd/version.rb
@@ -1,4 +1,4 @@
 module RailsERD
-  VERSION = "1.5.1"
+  VERSION = "1.5.2"
   BANNER  = "RailsERD #{VERSION}"
 end


### PR DESCRIPTION
Disables calls to `eager_load_namespaces` in anything older than Rails 5