### PR TITLE
Fix only_recursion_depth option failure when used from rake erd task

### DIFF
--- a/lib/rails_erd/tasks.rake
+++ b/lib/rails_erd/tasks.rake
@@ -19,6 +19,7 @@ namespace :erd do
       when "true", "yes" then true
       when "false", "no" then false
       when /,/ then ENV[option].split(/\s*,\s*/)
+      when /^\d+$/ then ENV[option].to_i
       else ENV[option].to_sym
       end
     end

--- a/test/unit/rake_task_test.rb
+++ b/test/unit/rake_task_test.rb
@@ -173,4 +173,16 @@ Error occurred while loading application: FooBar (RuntimeError)
     Rake::Task["erd:options"].execute
     assert_equal %w[content timestamps], RailsERD.options.attributes
   end
+
+  test "options task should set known integer command line options when value is only digits" do
+    ENV["only_recursion_depth"] = "2"
+    Rake::Task["erd:options"].execute
+    assert_equal 2, RailsERD.options.only_recursion_depth
+  end
+
+  test "options task sets known command line options as symbols when not boolean or numeric" do
+    ENV["only_recursion_depth"] = "test"
+    Rake::Task["erd:options"].execute
+    assert_equal :test, RailsERD.options.only_recursion_depth
+  end
 end


### PR DESCRIPTION
By default the value of only_recursion_depth is converted to a symbol.
This then fails to convert to an integer in RailsERD::diagram.generate.

This change fixes the issue by converting the option value to an int if
it only contains digits.