### PR TITLE
Gallery: Drop the 3 from Rails 3

### DIFF
--- a/gallery.html
+++ b/gallery.html
@@ -7,7 +7,7 @@ title: Gallery of example diagrams
   Browse this page to see some example diagrams.
   Many of them are generated from <strong>actual applications</strong>.
   Want to try for yourself? See the <a href="{{site.baseurl}}/install.html">installation instructions</a>.
-  If you have a great example diagram of an open source Rails 3 project that
+  If you have a great example diagram of an open source Rails project that
   you wish to share, get in touch!
 </p>
 


### PR DESCRIPTION
This PR removes one reference to "Rails 3" from a page in the explanatory site.

