### PR TITLE
Install page: Rails 3 references updated to reflect "3+"

### DIFF
--- a/install.html
+++ b/install.html
@@ -36,8 +36,8 @@ title: Installation instructions
 
 <h2><a name="install-rails-erd">Install Rails ERD</a></h2>
 <p>
-  Rails ERD runs on all Rails 3 platforms: Ruby 1.8/1.9, Rubinius, or JRuby
-  all work fine. Add Rails ERD as a plugin to your Ruby on Rails 3
+  Rails ERD runs on all Rails 3+ platforms: Ruby 1.8/1.9, Rubinius, or JRuby
+  all work fine. Add Rails ERD as a plugin to your Ruby on Rails
   application. In your <tt>Gemfile</tt>...
 </p>
 
@@ -70,7 +70,7 @@ end
 
 <h2><a name="without-rails">Not using Rails?</a></h2>
 <p>
-  If you use Active Record 3 outside of a Rails application, you can also use Rails
+  If you use Active Record 3+ outside of a Rails application, you can also use Rails
   ERD to create model diagrams for you. Install the <tt>rails-erd</tt> gem, load your
   models, and execute...
 </p>


### PR DESCRIPTION
This PR updates the docs site to not say "Rails 3" so very often.

- In cases where version is important "3+" has been kept, as a note.