### PR TITLE
Allow extra config files to be listed via cli

### DIFF
--- a/lib/rails_erd/cli.rb
+++ b/lib/rails_erd/cli.rb
@@ -150,7 +150,7 @@ module RailsERD
             opts[key.to_sym] = value
           end
         end
-        if options[:config_file] != ''
+        if options[:config_file] && options[:config_file] != ''
           RailsERD.options = RailsERD.default_options.merge(Config.load(options[:config_file]))
         end
         new(path, options).start

--- a/lib/rails_erd/cli.rb
+++ b/lib/rails_erd/cli.rb
@@ -1,3 +1,4 @@
+require "rails_erd"
 require "choice"
 
 Choice.options do
@@ -125,6 +126,12 @@ Choice.options do
       exit
     end
   end
+
+  option :config_file do
+    short "-c"
+    long "--config=FILENAME"
+    desc "Configuration file to use"
+  end
 end
 
 module RailsERD
@@ -142,6 +149,9 @@ module RailsERD
           else
             opts[key.to_sym] = value
           end
+        end
+        if options[:config_file] != ''
+          RailsERD.options = RailsERD.default_options.merge(Config.load(options[:config_file]))
         end
         new(path, options).start
       end

--- a/lib/rails_erd/config.rb
+++ b/lib/rails_erd/config.rb
@@ -7,17 +7,21 @@ module RailsERD
 
     attr_reader :options
 
-    def self.load
-      new.load
+    def self.load(extra_config_file=nil)
+      new.load extra_config_file
     end
 
     def initialize
       @options = {}
     end
 
-    def load
+    def load(extra_config_file=nil)
       load_file(USER_WIDE_CONFIG_FILE)
       load_file(CURRENT_CONFIG_FILE)
+      if extra_config_file
+        extra_config_path = File.expand_path(extra_config_file, Dir.pwd)
+        load_file(extra_config_path) if File.exist?(extra_config_path)
+      end
 
       @options
     end

--- a/test/unit/config_test.rb
+++ b/test/unit/config_test.rb
@@ -61,6 +61,29 @@ class ConfigTest < ActiveSupport::TestCase
     assert_equal expected_hash, RailsERD::Config.load
   end
 
+  test "load_config_file should return a hash from the configured config file when a new config file is given as an argument" do
+    set_local_config_file_to("erdconfig.another_example")
+
+    expected_hash = {
+      attributes:   [:content, :foreign_key, :inheritance, :false],
+      disconnected: true,
+      filename:     "erd",
+      filetype:     :pdf,
+      indirect:     true,
+      inheritance:  false,
+      markup:       true,
+      notation:     :simple,
+      orientation:  "horizontal",
+      polymorphism: false,
+      warn:         true,
+      title:        "sample title",
+      exclude:      [],
+      only:         []
+    }
+
+    assert_equal expected_hash, RailsERD::Config.load("test/support_files/erdconfig.example")
+  end
+
   test "load_config_gile should return a hash from CURRENT_CONFIG_FILE overriding USER_WIDE_CONFIG_FILE when both of them exist." do
     set_user_config_file_to("erdconfig.example")
     set_local_config_file_to("erdconfig.another_example")


### PR DESCRIPTION
In applications with complex entities having the ability to generate multiple ERDs with different settings is useful. For example, each diagram could be focused on a specific segment of the data model.