### PR TITLE
Deprecate safe_level of ERB.new in Ruby 2.6

### DIFF
--- a/lib/rails_erd/diagram/graphviz.rb
+++ b/lib/rails_erd/diagram/graphviz.rb
@@ -310,7 +310,12 @@ module RailsERD
       end
 
       def read_template(type)
-        ERB.new(File.read(File.expand_path("templates/#{NODE_LABEL_TEMPLATES[type]}", File.dirname(__FILE__))), nil, "<>")
+        template_text = File.read(File.expand_path("templates/#{NODE_LABEL_TEMPLATES[type]}", File.dirname(__FILE__)))
+        if ERB.instance_method(:initialize).parameters.assoc(:key) # Ruby 2.6+
+          ERB.new(template_text, trim_mode: "<>")
+        else
+          ERB.new(template_text, nil, "<>")
+        end
       end
     end
   end


### PR DESCRIPTION
This PR suppresses the following warnings.

```console
bundle exec rake
/Users/koic/src/github.com/voormedia/rails-erd/lib/rails_erd/diagram/graphviz.rb:313:
warning: Passing safe_level with the 2nd argument of ERB.new is
deprecated. Do not use it, and specify other arguments as keyword
arguments.
/Users/koic/src/github.com/voormedia/rails-erd/lib/rails_erd/diagram/graphviz.rb:313:
warning: Passing trim_mode with the 3rd argument of ERB.new is
deprecated. Use keyword argument like ERB.new(str, trim_mode: ...) instead.
```

The interface of `ERB.new` will change from Ruby 2.6.

> Add :trim_mode and :eoutvar keyword arguments to ERB.new.
> Now non-keyword arguments other than first one are softly deprecated
> and will be removed when Ruby 2.5 becomes EOL. [Feature #14256]

https://github.com/ruby/ruby/blob/2311087/NEWS#stdlib-updates-outstanding-ones-only