### PR TITLE
Fix for bug when parameter to only option is a single model

### DIFF
--- a/lib/rails_erd/tasks.rake
+++ b/lib/rails_erd/tasks.rake
@@ -19,7 +19,12 @@ namespace :erd do
       when "true", "yes" then true
       when "false", "no" then false
       when /,/ then ENV[option].split(/\s*,\s*/)
-      else ENV[option].to_sym
+      else
+	if option == 'only'
+	  [ENV[option].flatten
+        else
+	  ENV[option].to_sym
+	end
       end
     end
   end

--- a/test/unit/rake_task_test.rb
+++ b/test/unit/rake_task_test.rb
@@ -173,4 +173,10 @@ Error occurred while loading application: FooBar (RuntimeError)
     Rake::Task["erd:options"].execute
     assert_equal %w[content timestamps], RailsERD.options.attributes
   end
+
+  test "options task should set single parameter to only as array xxx" do
+    ENV["only"] = "model"
+    Rake::Task["erd:options"].execute
+    assert_equal ["model"], RailsERD.options.only
+  end
 end


### PR DESCRIPTION
The handling code expects the parameter to be an array and fails if it is a
symbol.

### **Please Note:**
I was not able to get the test suite running. I get the same error as is currently on the Travis-CI.