### PR TITLE
Pin minitest to 5.10.1

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -7,6 +7,7 @@ if ENV["edge"]
 end
 
 group :development do
+  gem 'minitest', '5.10.1'
   gem 'mocha'
   gem "rake"
   gem "yard"
@@ -29,4 +30,8 @@ group :development do
     gem "activerecord-jdbcsqlite3-adapter"
     gem "jruby-openssl", :require => false # Silence openssl warnings.
   end
+end
+
+group :test do
+  gem 'minitest', '5.10.1'
 end

--- a/gemfiles/Gemfile-rails.3.2.x
+++ b/gemfiles/Gemfile-rails.3.2.x
@@ -5,7 +5,7 @@ gemspec :path => ".."
 gem "activerecord", "~> 3.2.0"
 
 group :development do
-  gem 'mocha'
+  gem 'mocha', '1.4.0'
   gem "rake"
   gem "yard"
 

--- a/gemfiles/Gemfile-rails.4.1.x
+++ b/gemfiles/Gemfile-rails.4.1.x
@@ -5,6 +5,7 @@ gemspec :path => ".."
 gem "activerecord", "~> 4.1.0"
 
 group :development do
+  gem 'minitest', '5.10.1'
   gem 'mocha'
   gem "rake"
   gem "yard"

--- a/gemfiles/Gemfile-rails.4.2.x
+++ b/gemfiles/Gemfile-rails.4.2.x
@@ -5,6 +5,7 @@ gemspec :path => ".."
 gem "activerecord", "~> 4.2.0"
 
 group :development do
+  gem 'minitest', '5.10.1'
   gem 'mocha'
   gem "rake"
   gem "yard"

--- a/gemfiles/Gemfile-rails.5.0.x
+++ b/gemfiles/Gemfile-rails.5.0.x
@@ -5,6 +5,7 @@ gemspec :path => ".."
 gem "activerecord", "~> 5.0.2"
 
 group :development do
+  gem 'minitest', '5.10.1'
   gem 'mocha'
   gem "rake"
   gem "yard"


### PR DESCRIPTION
I got back into the project this morning and noticed a TON of test
failures in recent PRs. 5 min of research led me to these issues in
recent versions of minitest and Rails. Since we use a variety of Rails
versions, pinning the version minitest to one that works across legacy
Rails versions is a solution for today, but we may have to take a look
at a more sophisticated solution in the future.

seattlerb/minitest#730
rails/rails#31624