### PR TITLE
⚠ ambiguous first argument; put parentheses or a space even after `/' operator

### DIFF
--- a/lib/rails_erd/domain/entity.rb
+++ b/lib/rails_erd/domain/entity.rb
@@ -93,7 +93,7 @@ module RailsERD
       end
 
       def namespace
-        $1 if name.match /(.*)::.*/
+        $1 if name.match(/(.*)::.*/)
       end
 
       def to_s # @private :nodoc:


### PR DESCRIPTION
Here's a fix for a trivial Ruby warning.
FYI following is a quick step to reproduce the warning.

`% ruby -rrails-erd -we "require 'rails_erd/domain/entity'"`