### PR TITLE
Silence deprecation warning from the rename of `Module#parent` to `Module#module_parent`

### DIFF
--- a/lib/rails_erd/domain.rb
+++ b/lib/rails_erd/domain.rb
@@ -49,7 +49,13 @@ module RailsERD
     # Returns the domain model name, which is the name of your Rails
     # application or +nil+ outside of Rails.
     def name
-      defined? Rails and Rails.application and Rails.application.class.parent.name
+      return unless defined?(Rails) && Rails.application
+
+      if Rails.application.class.respond_to?(:module_parent)
+        Rails.application.class.module_parent.name
+      else
+        Rails.application.class.parent.name
+      end
     end
 
     # Returns all entities of your domain model.


### PR DESCRIPTION
> DEPRECATION WARNING: `Module#parent` has been renamed to `module_parent`. `parent` is deprecated and will be removed in Rails 6.1.

Rails 6 deprecated `Module#parent` and friends in rails/rails#34051, replacing them with a `module_*`-prefix naming scheme. This checks to see if `module_parent` is defined, using it if it's available.