### PR TITLE
Map foreign keys & current column name to symbols

### DIFF
--- a/lib/rails_erd/domain/attribute.rb
+++ b/lib/rails_erd/domain/attribute.rb
@@ -78,8 +78,8 @@ module RailsERD
       # relationship.
       def foreign_key?
         @domain.relationships_by_entity_name(@model.name).map(&:associations).flatten.map { |associaton|
-          associaton.send(Domain.foreign_key_method_name)
-        }.include?(name)
+          associaton.send(Domain.foreign_key_method_name).to_sym
+        }.include?(name.to_sym)
       end
 
       # Returns +true+ if this attribute is used for single table inheritance.


### PR DESCRIPTION
Sometimes column names will be strings instead of symbols.