### PR TITLE
Rails 6.1 Compatibility

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,7 @@ gemfile:
   - gemfiles/Gemfile-rails.5.1.x
   - gemfiles/Gemfile-rails.5.2.x
   - gemfiles/Gemfile-rails.6.0.x
+  - gemfiles/Gemfile-rails.6.1.x
   - gemfiles/Gemfile-rails.edge
 before_install:
   - gem install bundler -v '< 2'
@@ -34,6 +35,8 @@ matrix:
       gemfile: gemfiles/Gemfile-rails.edge
     - rvm: 2.4
       gemfile: gemfiles/Gemfile-rails.6.0.x
+    - rvm: 2.4
+      gemfile: gemfiles/Gemfile-rails.6.1.x
     - rvm: 2.4
       gemfile: gemfiles/Gemfile-rails.edge
 cache: bundler

--- a/.travis.yml
+++ b/.travis.yml
@@ -28,9 +28,13 @@ matrix:
     - rvm: 2.2
       gemfile: gemfiles/Gemfile-rails.6.0.x
     - rvm: 2.2
+      gemfile: gemfiles/Gemfile-rails.6.1.x
+    - rvm: 2.2
       gemfile: gemfiles/Gemfile-rails.edge
     - rvm: 2.3
       gemfile: gemfiles/Gemfile-rails.6.0.x
+    - rvm: 2.3
+      gemfile: gemfiles/Gemfile-rails.6.1.x
     - rvm: 2.3
       gemfile: gemfiles/Gemfile-rails.edge
     - rvm: 2.4

--- a/Gemfile
+++ b/Gemfile
@@ -17,8 +17,8 @@ group :development do
   gem "yard"
 
   platforms :ruby do
-    gem "activerecord", "< 6.1"
-    gem "activesupport", "< 6.1"
+    gem "activerecord", "< 7.0"
+    gem "activesupport", "< 7.0"
     gem "sqlite3", '~> 1.4'
     gem "redcarpet"
 

--- a/Gemfile
+++ b/Gemfile
@@ -6,19 +6,20 @@ if ENV["edge"]
   gem "activerecord", :github => "rails/rails"
 end
 
+
+group :development, :test do
+  gem 'minitest', '~> 5.14.0'
+end
+
 group :development do
-  gem 'minitest', '5.10.1'
   gem 'mocha'
   gem "rake"
   gem "yard"
 
-  platforms :ruby_21 do
-    gem "activerecord", "< 5.0"
-    gem "activesupport", "< 5.0"
-  end
-
   platforms :ruby do
-    gem "sqlite3"
+    gem "activerecord", "< 6.1"
+    gem "activesupport", "< 6.1"
+    gem "sqlite3", '~> 1.4'
     gem "redcarpet"
 
     if RUBY_VERSION > "2.1.0"
@@ -30,8 +31,4 @@ group :development do
     gem "activerecord-jdbcsqlite3-adapter"
     gem "jruby-openssl", :require => false # Silence openssl warnings.
   end
-end
-
-group :test do
-  gem 'minitest', '5.10.1'
 end

--- a/gemfiles/Gemfile-rails.6.1.x
+++ b/gemfiles/Gemfile-rails.6.1.x
@@ -1,0 +1,21 @@
+source "http://rubygems.org"
+
+gemspec :path => ".."
+
+gem "activerecord", "~> 6.1.1"
+
+group :development do
+  gem 'mocha'
+  gem "rake"
+  gem "yard"
+
+  platforms :ruby do
+    gem "sqlite3", '~> 1.4'
+    gem "redcarpet"
+  end
+
+  platforms :jruby do
+    gem "activerecord-jdbcsqlite3-adapter"
+    gem "jruby-openssl", :require => false # Silence openssl warnings.
+  end
+end

--- a/lib/rails_erd/domain.rb
+++ b/lib/rails_erd/domain.rb
@@ -49,7 +49,13 @@ module RailsERD
     # Returns the domain model name, which is the name of your Rails
     # application or +nil+ outside of Rails.
     def name
-      defined? Rails and Rails.application and Rails.application.class.parent.name
+      return unless defined?(Rails) && Rails.application
+
+      if Rails.application.class.respond_to?(:module_parent)
+        Rails.application.class.module_parent.name
+      else
+        Rails.application.class.parent.name
+      end
     end
 
     # Returns all entities of your domain model.

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -16,6 +16,14 @@ if ActiveSupport::TestCase.respond_to?(:test_order=)
   ActiveSupport::TestCase.test_order = :random
 end
 
+# Patch to make Rails 6.1 work.
+module Kernel
+  # class_eval on an object acts like singleton_class.class_eval.
+  def class_eval(*args, &block)
+    singleton_class.class_eval(*args, &block)
+  end
+end
+
 class ActiveSupport::TestCase
   include RailsERD
 

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -19,15 +19,11 @@ end
 class ActiveSupport::TestCase
   include RailsERD
 
-  setup :reset_config_file
+  setup    :reset_config_file
   teardown :reset_domain
 
   def create_table(table, columns = {}, pk = nil)
-    opts = if pk then
-             { :primary_key => pk }
-           else
-             { :id => false }
-           end
+    opts = if pk then { :primary_key => pk } else { :id => false } end
     ActiveRecord::Schema.instance_eval do
       suppress_messages do
         create_table table, opts do |t|
@@ -49,12 +45,12 @@ class ActiveSupport::TestCase
     ActiveRecord::Base.clear_cache!
   end
 
-  def create_module_model(full_name, *args, &block)
+  def create_module_model(full_name,*args,&block)
     superklass = args.first.kind_of?(Class) ? args.shift : ActiveRecord::Base
 
     names = full_name.split('::')
 
-    parent_module = names[0..-1].inject(Object) do |parent, child|
+    parent_module = names[0..-1].inject(Object) do |parent,child|
       parent = parent.const_set(child.to_sym, Module.new)
     end
 
@@ -159,11 +155,11 @@ class ActiveSupport::TestCase
   def reset_config_file
     RailsERD::Config.send :remove_const, :USER_WIDE_CONFIG_FILE
     RailsERD::Config.send :const_set, :USER_WIDE_CONFIG_FILE,
-                          File.expand_path("../../examples/erdconfig.not_exists", __FILE__)
+      File.expand_path("../../examples/erdconfig.not_exists", __FILE__)
 
     RailsERD::Config.send :remove_const, :CURRENT_CONFIG_FILE
     RailsERD::Config.send :const_set, :CURRENT_CONFIG_FILE,
-                          File.expand_path("../../examples/erdconfig.not_exists", __FILE__)
+      File.expand_path("../../examples/erdconfig.not_exists", __FILE__)
 
     RailsERD.options = RailsERD.default_options.merge(Config.load)
   end
@@ -173,7 +169,7 @@ class ActiveSupport::TestCase
 
     return [] if parts.first == '' || parts.count == 0
 
-    parts[1..-1].inject([[Object, parts.first.to_sym]]) do |pairs, string|
+    parts[1..-1].inject([[Object, parts.first.to_sym]]) do |pairs,string|
       last_parent, last_child = pairs.last
       # Fixes for Rails 6. No idea if this is actually correct as I can't decipher what the heck is going on in this
       # code.
@@ -192,7 +188,7 @@ class ActiveSupport::TestCase
   def remove_fully_qualified_constant(name)
     pairs = name_to_object_symbol_pairs(name)
     pairs.reverse.each do |parent, child|
-      parent.send(:remove_const, child) if parent.const_defined?(child)
+      parent.send(:remove_const,child) if parent.const_defined?(child)
     end
   end
 
@@ -208,7 +204,7 @@ class ActiveSupport::TestCase
         ActiveRecord::Base.connection.drop_table table
       end
 
-      if ActiveRecord::VERSION::MAJOR >= 6
+      if ActiveRecord.version >= Gem::Version.new("6.0.0.rc1")
         cv = ActiveSupport::DescendantsTracker.class_variable_get(:@@direct_descendants)
         cv.delete(ActiveRecord::Base)
         ActiveSupport::DescendantsTracker.class_variable_set(:@@direct_descendants, cv)

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -175,6 +175,8 @@ class ActiveSupport::TestCase
 
     parts[1..-1].inject([[Object, parts.first.to_sym]]) do |pairs, string|
       last_parent, last_child = pairs.last
+      # Fixes for Rails 6. No idea if this is actually correct as I can't decipher what the heck is going on in this
+      # code.
       if last_child == :ActiveRecord || last_child == :primary
         break []
       end

--- a/test/unit/attribute_test.rb
+++ b/test/unit/attribute_test.rb
@@ -267,11 +267,12 @@ class AttributeTest < ActiveSupport::TestCase
 
   test "limit should return nil for oddball column types that misuse the limit attribute" do
     create_model "Business", :location => :integer do
-    define_singleton_method :limit do
-      # https://github.com/voormedia/rails-erd/issues/21
-      { :srid => 4326, :type => "point", :geographic => true }
+      define_singleton_method :limit do
+        # https://github.com/voormedia/rails-erd/issues/21
+        { :srid => 4326, :type => "point", :geographic => true }
+      end
     end
-  end
+
     attribute = create_attribute(Business, "location")
     assert_nil attribute.limit
   end

--- a/test/unit/attribute_test.rb
+++ b/test/unit/attribute_test.rb
@@ -3,9 +3,9 @@ require File.expand_path("../test_helper", File.dirname(__FILE__))
 
 class AttributeTest < ActiveSupport::TestCase
   def with_native_limit(type, new_limit)
-    ActiveRecord::Base.connection.class_eval do
+    ActiveRecord::Base.connection.singleton_class.class_eval do
       undef :native_database_types
-      define_method :native_database_types do
+      define_method(:native_database_types) do
         super().tap do |types|
           types[type][:limit] = new_limit
         end
@@ -13,9 +13,9 @@ class AttributeTest < ActiveSupport::TestCase
     end
     yield
   ensure
-    ActiveRecord::Base.connection.class_eval do
+    ActiveRecord::Base.connection.singleton_class.class_eval do
       undef :native_database_types
-      define_method :native_database_types do
+      define_method(:native_database_types) do
         super()
       end
     end
@@ -266,14 +266,13 @@ class AttributeTest < ActiveSupport::TestCase
   end
 
   test "limit should return nil for oddball column types that misuse the limit attribute" do
-    create_model "Business", :location => :integer
-    attribute = create_attribute(Business, "location")
-    attribute.column.class_eval do
-      define_method :limit do
-        # https://github.com/voormedia/rails-erd/issues/21
-        { :srid => 4326, :type => "point", :geographic => true }
-      end
+    create_model "Business", :location => :integer do
+    define_singleton_method :limit do
+      # https://github.com/voormedia/rails-erd/issues/21
+      { :srid => 4326, :type => "point", :geographic => true }
     end
+  end
+    attribute = create_attribute(Business, "location")
     assert_nil attribute.limit
   end
 
@@ -306,13 +305,12 @@ class AttributeTest < ActiveSupport::TestCase
   end
 
   test "scale should return nil for oddball column types that misuse the scale attribute" do
-    create_model "Kobold", :size => :integer
-    attribute = create_attribute(Kobold, "size")
-    attribute.column.class_eval do
+    create_model "Kobold", :size => :integer do
       define_method :scale do
         1..5
       end
     end
+    attribute = create_attribute(Kobold, "size")
     assert_nil attribute.scale
   end
 end


### PR DESCRIPTION
I'll be completely honest, this fix works, but I haven't spent the time to guarantee this is the "right" way to update this library for Rails 6.1 compatibility. Due to the way the tests fiddle with the innards of ActiveRecord, it seems like this library is only a few more major Rails releases away from needing its tests rewritten.

I saw the comments on https://github.com/voormedia/rails-erd/pull/345 by @gee-forr and several others, hopefully I'll be able to get the tests in travis happy if/when they fail.