### PR TITLE
add optional configuration to set which fonts to use

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,10 @@ only_recursion_depth: null
 prepend_primary: false
 cluster: false
 splines: spline
+fonts:
+ normal: "Arial"
+ bold: "Arial Bold"
+ italic: "Arial Italic"
 ```
 
 Auto generation

--- a/examples/erdconfig.example
+++ b/examples/erdconfig.example
@@ -20,3 +20,7 @@ only: null
 only_recursion_depth: null
 prepend_primary: false
 cluster: false
+fonts:
+ normal: "Arial"
+ bold: "Arial Bold"
+ italic: "Arial Italic"

--- a/lib/rails_erd.rb
+++ b/lib/rails_erd.rb
@@ -40,6 +40,7 @@ module RailsERD
         :disconnected, true,
         :filename, "erd",
         :filetype, :pdf,
+        :fonts, {},
         :indirect, true,
         :inheritance, false,
         :markup, true,

--- a/lib/rails_erd/config.rb
+++ b/lib/rails_erd/config.rb
@@ -81,6 +81,12 @@ module RailsERD
       when :title
         value.is_a?(String) ? value : !!value
 
+      # nil | <Hash>
+      when :fonts
+        if value
+          Hash(value).transform_keys(&:to_sym)
+        end
+
       else
         value
       end

--- a/lib/rails_erd/diagram/graphviz.rb
+++ b/lib/rails_erd/diagram/graphviz.rb
@@ -50,7 +50,7 @@ module RailsERD
 
       NODE_WIDTH = 130 # @private :nodoc:
 
-      FONTS = Config.font_names_based_on_os
+      FONTS = Config.font_names_based_on_os.merge(RailsERD.options[:fonts])
 
       # Default graph attributes.
       GRAPH_ATTRIBUTES = {

--- a/test/unit/config_test.rb
+++ b/test/unit/config_test.rb
@@ -115,6 +115,12 @@ class ConfigTest < ActiveSupport::TestCase
     assert_equal [:content, :primary_keys], normalize_value(:attributes, ["content", "primary_keys"])
   end
 
+  test "normalize_value should return hash with symbol keys when key is :fonts and value is a hash." do
+    fonts_value = { "normal" => "Arial", "bold" => "Arial Bold", "italic" => "Arial Italic" }
+    expected = {:normal => "Arial", :bold => "Arial Bold", :italic => "Arial Italic"}
+    assert_equal expected, normalize_value(:fonts, fonts_value)
+  end
+
   def normalize_value(key, value)
     RailsERD::Config.new.send(:normalize_value, key, value)
   end

--- a/test/unit/graphviz_test.rb
+++ b/test/unit/graphviz_test.rb
@@ -186,6 +186,16 @@ class GraphvizTest < ActiveSupport::TestCase
     assert_equal '"Domain model\n\n"', diagram.graph.graph[:label].to_s
   end
 
+  test "generate should use default value for fontname attribute" do
+    create_simple_domain
+    assert_equal "\"#{RailsERD::Config.font_names_based_on_os[:bold]}\"", diagram.graph.graph[:fontname].to_s
+  end
+
+  test "generate should add set value for fontname attribute" do
+    create_simple_domain
+    assert_equal '"Arial Bold"', diagram(fonts: {bold: "Arial Bold"}).graph.graph[:fontname].to_s
+  end
+
   test "generate should add default value for splines attribute" do
     create_simple_domain
     assert_equal '"spline"', diagram.graph.graph[:splines].to_s


### PR DESCRIPTION
This PR adds the ability to optionally configure font faces to use in the generated diagram.

While working on a [PR in the rubygems.org repo](https://github.com/rubygems/rubygems.org/pull/3043) to check the ERD in a Github action whenever the database schema changes (to ensure it's kept up to date), we realized that some of the diffs are dependent on what fonts the user has installed on their local machine.

By having optional configuration for fonts, the user can explicitly choose to bypass OS-dependent fonts for more consistent generated files.

Note: When I tried to run the tests, the output was super noisy (even without my changes) so I must have missed a set up step? Apologies if these tests are broken. I'll fix them if they are.

