### PR TITLE
Introduce GitHub Actions.

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,32 @@
+name: Tests
+on:
+  pull_request:
+  push:
+    branches:
+      - master
+permissions:
+  contents: read
+
+jobs:
+  test:
+    runs-on: ubuntu-18.04
+    strategy:
+      matrix:
+        ruby_version: ['3.1', '3.0', '2.7']
+        rails_version: ['6.0.x', '6.1.x', '7.0.x', 'edge']
+    name: Ruby ${{ matrix.ruby_version }} on Rails ${{ matrix.rails_version }}
+    env:
+      BUNDLE_GEMFILE: ${{ github.workspace }}/gemfiles/Gemfile-rails.${{ matrix.rails_version }}
+    steps:
+    - name: Install graphviz
+      run: |
+        sudo apt-get update -qq
+        sudo apt-get install -qq graphviz
+    - uses: actions/checkout@v3
+    - uses: ruby/setup-ruby@v1
+      with:
+        ruby-version: ${{ matrix.ruby_version }}
+        bundler-cache: true
+    - name: Run tests
+      run: |
+        bundle exec rake test


### PR DESCRIPTION
Life is easier with smoothly running CI. I have ported CI to use GitHub Actions. For now, I have introduced only supported Ruby and Rails versions.

If welcomed, I can contribute to new version supporting only those (do some cleanups in code and README.md) and we can cut new major release.

Otherwise I can try to port older versions to CI as well.

Other possible improvement is to move Rails edge CI to weekly build, ping me if that would be welcomed as well.

PS: You can see CI in action at https://github.com/RubyElders/rails-erd/pull/1.