### PR TITLE
Supress warnings for tableless Rails models

### DIFF
--- a/test/unit/domain_test.rb
+++ b/test/unit/domain_test.rb
@@ -283,4 +283,14 @@ class DomainTest < ActiveSupport::TestCase
     end
     assert_match(/Ignoring invalid model Foo \(table foos does not exist\)/, output)
   end
+
+  test "entities should not output a warning when a Rails model table does not exist" do
+    module ActionMailbox; end
+
+    Object.const_set :InboundEmail, ActionMailbox
+    output = collect_stdout do
+      Domain.generate.entities
+    end
+    assert_equal "", output
+  end
 end


### PR DESCRIPTION
Closes https://github.com/voormedia/rails-erd/issues/389

Please note this approach still allows users to specify the Rails models if they want to see them on their graph, it just doesn't complain if the Rails generator has not been run and tables created.