### PR TITLE
(Mermaid)  Draw relationships only for Entity drawn on the screen.

### DIFF
--- a/lib/rails_erd/diagram/mermaid.rb
+++ b/lib/rails_erd/diagram/mermaid.rb
@@ -76,13 +76,8 @@ module RailsERD
       end
 
       def node_exists?(name)
-        # 適切な判定方法かというとイマイチだが変なモデル名でなければこれで動きはする
         # I'm not sure if this is the proper way to judge, but it works as long as you don't use a weird model name.
         graph.include?("\tclass `#{name}`")
-      end
-
-      def escape_name(name)
-        name
       end
 
     end

--- a/lib/rails_erd/diagram/mermaid.rb
+++ b/lib/rails_erd/diagram/mermaid.rb
@@ -31,6 +31,8 @@ module RailsERD
 
       each_relationship do |relationship|
         from, to = relationship.source, relationship.destination
+        next unless node_exists?(from) && node_exists?(to)
+
         graph << "\t`#{from.name}` #{relation_arrow(relationship)} `#{to.name}`"
 
         from.children.each do |child|
@@ -71,6 +73,15 @@ module RailsERD
 
       def arrow_tail(relationship)
         relationship.many_to? ? "<" : ""
+      end
+
+      def node_exists?(name)
+        # 適切な判定方法かというとイマイチだが変なモデル名でなければこれで動きはする
+        graph.include?("\tclass `#{name}`")
+      end
+
+      def escape_name(name)
+        name
       end
 
     end

--- a/lib/rails_erd/diagram/mermaid.rb
+++ b/lib/rails_erd/diagram/mermaid.rb
@@ -77,6 +77,7 @@ module RailsERD
 
       def node_exists?(name)
         # 適切な判定方法かというとイマイチだが変なモデル名でなければこれで動きはする
+        # I'm not sure if this is the proper way to judge, but it works as long as you don't use a weird model name.
         graph.include?("\tclass `#{name}`")
       end
 


### PR DESCRIPTION
```
only: Model1,Model2
```
のようにModelを限定した場合に、指定していないModelの分も線が引かれてしまうので条件を追加した
When Model is limited as above, the line is drawn for the Model that is not specified, so I added a condition.

---

OSSのコミットに慣れていないので誰かこの修正をパクってマージしていただけると嬉しい・・・
