### PR TITLE
mod uninitialized constant RailsERD::Diagram Error

### DIFF
--- a/lib/rails_erd/cli.rb
+++ b/lib/rails_erd/cli.rb
@@ -8,6 +8,7 @@ Choice.options do
   option :generator do
     long "--generator=Generator"
     desc "Generator to use (graphviz or mermaid). Defaults to graphviz."
+    default "graphviz"
   end
 
   option :title do
@@ -164,7 +165,8 @@ module RailsERD
 
     def initialize(path, options)
       @path, @options = path, options
-      require "rails_erd/diagram/graphviz" if options.generator == :graphviz
+      require "rails_erd/diagram/graphviz" if options[:generator] == 'graphviz'
+      require "rails_erd/diagram/mermaid" if options[:generator] == 'mermaid'
     end
 
     def start
@@ -202,7 +204,7 @@ module RailsERD
     end
 
     def generator
-      if options.generator == :mermaid
+      if options[:generator] == 'mermaid'
         RailsERD::Diagram::Mermaid
       else
         RailsERD::Diagram::Graphviz


### PR DESCRIPTION
Thank you for creating the template for outputting Mermaid with RailsERD!

When I ran ERD on the latest master branch, I encountered the following error:

```sh
$ bundle exec erd --debug
Loading application in 'project_name'...
Generating entity-relationship diagram for 25 models...
Failed: NameError: uninitialized constant RailsERD::Diagram
    from /usr/local/bundle/bundler/gems/rails-erd-6f4f8b451e64/lib/rails_erd/cli.rb:209:in `generator'
    from /usr/local/bundle/bundler/gems/rails-erd-6f4f8b451e64/lib/rails_erd/cli.rb:215:in `create_diagram'
    from /usr/local/bundle/bundler/gems/rails-erd-6f4f8b451e64/lib/rails_erd/cli.rb:173:in `start'
    from /usr/local/bundle/bundler/gems/rails-erd-6f4f8b451e64/lib/rails_erd/cli.rb:162:in `start'
    from /usr/local/bundle/bundler/gems/rails-erd-6f4f8b451e64/bin/erd:4:in `<top (required)>'
    from /usr/local/bundle/bin/erd:23:in `load'
    from /usr/local/bundle/bin/erd:23:in `<top (required)>'
    from /usr/local/lib/ruby/2.7.0/bundler/cli/exec.rb:63:in `load'
    from /usr/local/lib/ruby/2.7.0/bundler/cli/exec.rb:63:in `kernel_load'
    from /usr/local/lib/ruby/2.7.0/bundler/cli/exec.rb:28:in `run'
    from /usr/local/lib/ruby/2.7.0/bundler/cli.rb:476:in `exec'
    from /usr/local/lib/ruby/2.7.0/bundler/vendor/thor/lib/thor/command.rb:27:in `run'
    from /usr/local/lib/ruby/2.7.0/bundler/vendor/thor/lib/thor/invocation.rb:127:in `invoke_command'
    from /usr/local/lib/ruby/2.7.0/bundler/vendor/thor/lib/thor.rb:399:in `dispatch'
    from /usr/local/lib/ruby/2.7.0/bundler/cli.rb:30:in `dispatch'
    from /usr/local/lib/ruby/2.7.0/bundler/vendor/thor/lib/thor/base.rb:476:in `start'
    from /usr/local/lib/ruby/2.7.0/bundler/cli.rb:24:in `start'
    from /usr/local/lib/ruby/gems/2.7.0/gems/bundler-2.1.4/libexec/bundle:46:in `block in <top (required)>'
    from /usr/local/lib/ruby/2.7.0/bundler/friendly_errors.rb:123:in `with_friendly_errors'
    from /usr/local/lib/ruby/gems/2.7.0/gems/bundler-2.1.4/libexec/bundle:34:in `<top (required)>'
    from /usr/local/bin/bundle:23:in `load'
    from /usr/local/bin/bundle:23:in `<main>'
```

I have fixed the error, so please check it.
