### PR TITLE
Surpress warnings for missing SolidQueue tables

### DIFF
--- a/lib/rails_erd/cli.rb
+++ b/lib/rails_erd/cli.rb
@@ -164,7 +164,7 @@ module RailsERD
 
     def initialize(path, options)
       @path, @options = path, options
-      require "rails_erd/diagram/graphviz" if options.generator == :graphviz
+      require "rails_erd/diagram/graphviz" if options[:generator] == :graphviz
     end
 
     def start

--- a/lib/rails_erd/domain.rb
+++ b/lib/rails_erd/domain.rb
@@ -135,6 +135,20 @@ module RailsERD
         ActiveStorage::VariantRecord
         ActionText::RichText
         ActionText::EncryptedRichText
+        SolidQueue::Message
+        SolidCache::Entry
+        SolidQueue::Semaphore
+        SolidQueue::RecurringTask
+        SolidQueue::Process
+        SolidQueue::Pause
+        SolidQueue::Job
+        SolidQueue::ScheduledExecution
+        SolidQueue::RecurringExecution
+        SolidQueue::ReadyExecution
+        SolidQueue::FailedExecution
+        SolidQueue::ClaimedExecution
+        SolidQueue::BlockedExecution
+        SolidQueue::Execution
       ).map{ |model| Object.const_get(model) rescue nil }.compact
     end
 


### PR DESCRIPTION
The new SolidQueue namespaced tables are causing warnings if they don't exist. This PR supressess the warnings, and is a follow-on to https://github.com/voormedia/rails-erd/pull/390

Example

```
❯ rake immersive:erd:events
erd --only 'Community,Event,EventRound,EventRegistration,User,EventGroup,EventGroupMember,EventMemberEvaluation' --notation bachman --attributes foreign_keys,content --title false --orientation=horizontal --filename=docs/technical/erds/events --inheritance --open
Loading application in 'immersive-app'...
Tried to load your application environment from '/Users/sean/immersive/immersive-app/config/environment.rb' but the file was not present.
This means that your models might not get loaded fully when the diagram gets built. This can
make your entity diagram incomplete.

However, if you are using ActiveRecord without Rails just make sure your models get
loaded eagerly before we generate the ERD (for example, explicitly require your application
bootstrap file before calling rails-erd from your Rakefile). We will continue without loading the environment file,
and recommend you check your diagram for missing models after it gets generated.
Generating entity-relationship diagram for 35 models...
Warning: Ignoring invalid model SolidCable::Message (table solid_cable_messages does not exist)
Warning: Ignoring invalid model SolidCache::Entry (table solid_cache_entries does not exist)
Warning: Ignoring invalid model SolidQueue::Semaphore (table solid_queue_semaphores does not exist)
Warning: Ignoring invalid model SolidQueue::RecurringTask (table solid_queue_recurring_tasks does not exist)
Warning: Ignoring invalid model SolidQueue::Process (table solid_queue_processes does not exist)
Warning: Ignoring invalid model SolidQueue::Pause (table solid_queue_pauses does not exist)
Warning: Ignoring invalid model SolidQueue::Job (table solid_queue_jobs does not exist)
Warning: Ignoring invalid model SolidQueue::ScheduledExecution (table solid_queue_scheduled_executions does not exist)
Warning: Ignoring invalid model SolidQueue::RecurringExecution (table solid_queue_recurring_executions does not exist)
Warning: Ignoring invalid model SolidQueue::ReadyExecution (table solid_queue_ready_executions does not exist)
Warning: Ignoring invalid model SolidQueue::FailedExecution (table solid_queue_failed_executions does not exist)
Warning: Ignoring invalid model SolidQueue::ClaimedExecution (table solid_queue_claimed_executions does not exist)
Warning: Ignoring invalid model SolidQueue::BlockedExecution (table solid_queue_blocked_executions does not exist)
Warning: Ignoring invalid association :job on SolidQueue::Execution (model SolidQueue::Job exists, but is not included in domain)
Warning: Ignoring invalid association :invited_by on User (polymorphic interface InvitedBy does not exist)
Diagram saved to 'docs/technical/erds/events.pdf'.
```