### PR TITLE
load rake tasks whenever railtie is loaded

### DIFF
--- a/lib/generators/erd/templates/auto_generate_diagram.rake
+++ b/lib/generators/erd/templates/auto_generate_diagram.rake
@@ -1,6 +1,6 @@
 # NOTE: only doing this in development as some production environments (Heroku)
 # NOTE: are sensitive to local FS writes, and besides -- it's just not proper
 # NOTE: to have a dev-mode tool do its thing in production.
-if Rails.env.development?
+if defined? RailsERD
   RailsERD.load_tasks
 end


### PR DESCRIPTION
The decision for whether the tasks should be loaded should not be
determined by this gem, but instead managed by the environments in which
the Gemfile declares the gem to be loaded.

When rails-erd is in the development group, then the gem is only loaded
in development environments, and therefore RailsERD is only defined in
development.

This also resolves the _incidental_ coupling whereby the templatized
rake task _assumes_ that the only environment in which users want the
diagrams generated is development. (Or that users actually want the
tasks running in development in the first place.)

Instead, this change defers that decision to the Gemfile as the source
of truth for when the gem should be loaded, and therefore when the tasks
should be available.

Fixes #425 