### PR TITLE
Exclude Ruby 3.2 from Rails edge CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -19,6 +19,8 @@ jobs:
             rails_version: '8.0.x'
           - ruby_version: '3.1'
             rails_version: 'edge'
+          - ruby_version: '3.2'
+            rails_version: 'edge'
     name: Ruby ${{ matrix.ruby_version }} on Rails ${{ matrix.rails_version }}
     env:
       BUNDLE_GEMFILE: ${{ github.workspace }}/gemfiles/Gemfile-rails.${{ matrix.rails_version }}


### PR DESCRIPTION
Rails edge (main branch) now requires Ruby >= 3.3.1, so Ruby 3.2 cannot be used with it.

This fixes the CI failure after merging #422.

**Error from CI:**
```
Because every version of activerecord depends on Ruby >= 3.3.1
  and Gemfile-rails.edge depends on activerecord >= 0,
  Ruby >= 3.3.1 is required.
So, because current Ruby version is = 3.2.11,
  version solving has failed.
```