### PR TITLE
Fix frozen string literal warnings in graphviz.rb

### DIFF
--- a/lib/rails_erd/diagram/graphviz.rb
+++ b/lib/rails_erd/diagram/graphviz.rb
@@ -1,4 +1,5 @@
-# encoding: utf-8
+# frozen_string_literal: true
+
 require "rails_erd/diagram"
 require "graphviz"
 require "erb"
@@ -123,8 +124,8 @@ module RailsERD
             options[:style] = :dotted if relationship.indirect?
 
             # Cardinality is "look-across".
-            dst = relationship.to_many? ? "crow" : "tee"
-            src = relationship.many_to? ? "crow" : "tee"
+            dst = +(relationship.to_many? ? "crow" : "tee")
+            src = +(relationship.many_to? ? "crow" : "tee")
 
             # Participation is "look-across".
             dst << (relationship.destination_optional? ? "odot" : "tee")
@@ -143,8 +144,8 @@ module RailsERD
             options[:style] = :dotted if relationship.indirect?
 
             # Participation is "look-here".
-            dst = relationship.source_optional? ? "odot" : "dot"
-            src = relationship.destination_optional? ? "odot" : "dot"
+            dst = +(relationship.source_optional? ? "odot" : "dot")
+            src = +(relationship.destination_optional? ? "odot" : "dot")
 
             # Cardinality is "look-across".
             dst << "normal" if relationship.to_many?


### PR DESCRIPTION
## Summary

Fixes frozen string literal warnings that appear in Ruby 3.4 and will become errors in Ruby 3.5+.

## Changes

- Use unary `+` operator to create mutable strings before appending with `<<` in the Crowsfoot and Bachman notation modules
- Replace obsolete `# encoding: utf-8` magic comment with `# frozen_string_literal: true` pragma

## Problem

In Ruby 3.4+, mutating string literals produces warnings:
```
warning: literal string will be frozen in the future
```

The affected lines were building arrow notation strings like:
```ruby
dst = "crow"
dst << "odot"  # Warning: mutating a literal string
```

## Solution

Use the unary `+` operator to create a mutable copy:
```ruby
dst = +("crow")
dst << "odot"  # OK: mutating a mutable string
```

## Testing

Verified no warnings with `ruby -w` on Ruby 3.4.7.