### PR TITLE
Add frozen_string_literal pragma to all Ruby files

### DIFF
--- a/lib/generators/erd/install_generator.rb
+++ b/lib/generators/erd/install_generator.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Erd
   module Generators
     class InstallGenerator < Rails::Generators::Base

--- a/lib/rails-erd.rb
+++ b/lib/rails-erd.rb
@@ -1,1 +1,3 @@
+# frozen_string_literal: true
+
 require "rails_erd"

--- a/lib/rails_erd.rb
+++ b/lib/rails_erd.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "active_support/ordered_options"
 require "rails_erd/railtie" if defined? Rails
 require "rails_erd/config"

--- a/lib/rails_erd/cli.rb
+++ b/lib/rails_erd/cli.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "rails_erd"
 require "choice"
 

--- a/lib/rails_erd/config.rb
+++ b/lib/rails_erd/config.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "yaml"
 
 module RailsERD

--- a/lib/rails_erd/diagram.rb
+++ b/lib/rails_erd/diagram.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "rails_erd/domain"
 
 module RailsERD

--- a/lib/rails_erd/diagram/mermaid.rb
+++ b/lib/rails_erd/diagram/mermaid.rb
@@ -1,4 +1,5 @@
-# encoding: utf-8
+# frozen_string_literal: true
+
 require "rails_erd/diagram"
 require "erb"
 

--- a/lib/rails_erd/domain.rb
+++ b/lib/rails_erd/domain.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "rails_erd"
 require "rails_erd/domain/attribute"
 require "rails_erd/domain/entity"

--- a/lib/rails_erd/domain/attribute.rb
+++ b/lib/rails_erd/domain/attribute.rb
@@ -1,4 +1,4 @@
-# encoding: utf-8
+# frozen_string_literal: true
 
 #--
 module RailsERD

--- a/lib/rails_erd/domain/entity.rb
+++ b/lib/rails_erd/domain/entity.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module RailsERD
   class Domain
     # Entities represent your Active Record models. Entities may be connected

--- a/lib/rails_erd/domain/relationship.rb
+++ b/lib/rails_erd/domain/relationship.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "set"
 require "active_support/core_ext/module/delegation"
 require "rails_erd/domain/relationship/cardinality"

--- a/lib/rails_erd/domain/relationship/cardinality.rb
+++ b/lib/rails_erd/domain/relationship/cardinality.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module RailsERD
   class Domain
     class Relationship

--- a/lib/rails_erd/domain/specialization.rb
+++ b/lib/rails_erd/domain/specialization.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module RailsERD
   class Domain
     # Describes the specialization of an entity. Specialized entities correspond

--- a/lib/rails_erd/railtie.rb
+++ b/lib/rails_erd/railtie.rb
@@ -1,5 +1,7 @@
+# frozen_string_literal: true
+
 module RailsERD
-  # Rails ERD integrates with Rails 3. If you add it to your +Gemfile+, you
+  # Rails ERD integrates with Rails. If you add it to your +Gemfile+, you
   # will gain a Rake task called +erd+, which you can use to generate diagrams
   # of your domain model.
   class Railtie < Rails::Railtie

--- a/lib/rails_erd/version.rb
+++ b/lib/rails_erd/version.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module RailsERD
   VERSION = "1.7.2"
   BANNER  = "RailsERD #{VERSION}"


### PR DESCRIPTION
## Summary

Adds the `# frozen_string_literal: true` pragma to all Ruby files in `lib/`, preparing the codebase for Ruby 3.5 where frozen string literals will become the default.

## Changes

- Added pragma to all 15 Ruby files in `lib/`
- Replaced obsolete `# encoding: utf-8` comments in 2 files (obsolete since Ruby 2.0)
- Fixed outdated "Rails 3" reference in railtie.rb comment

## Why

1. **Ruby 3.5 preparation**: Frozen string literals will be the default in Ruby 3.5
2. **Performance**: Frozen strings can be deduplicated and reused, reducing memory
3. **Safety**: Prevents accidental string mutation bugs
4. **Consistency**: All files now follow the same convention

## Testing

All tests pass (323 runs, 1 unrelated font-name failure on macOS).