### PR TITLE
Update minimum Ruby/Rails versions and remove obsolete TODOs

### DIFF
--- a/rails-erd.gemspec
+++ b/rails-erd.gemspec
@@ -11,10 +11,10 @@ Gem::Specification.new do |s|
   s.description = "Automatically generate an entity-relationship diagram (ERD) for your Rails models."
   s.license     = "MIT"
 
-  s.required_ruby_version = '>= 2.2'
+  s.required_ruby_version = '>= 3.1'
 
-  s.add_runtime_dependency "activerecord", ">= 4.2"
-  s.add_runtime_dependency "activesupport", ">= 4.2"
+  s.add_runtime_dependency "activerecord", ">= 7.0"
+  s.add_runtime_dependency "activesupport", ">= 7.0"
   s.add_runtime_dependency "ruby-graphviz", "~> 1.2"
   s.add_runtime_dependency "choice", "~> 0.2.0"
 

--- a/test/unit/domain_test.rb
+++ b/test/unit/domain_test.rb
@@ -127,21 +127,16 @@ class DomainTest < ActiveSupport::TestCase
   end
 
   test "relationships should count relationship between same models with distinct foreign key seperately" do
-    # TODO: Once we drop Rails 3.2 support, we _should_ be able to drop the
-    #   :respond_to? check
-    #
-    if respond_to? :skip
-      skip("multiple edges between the same objects can cause segfaults in some versions of Graphviz")
+    skip("multiple edges between the same objects can cause segfaults in some versions of Graphviz")
 
-      create_model "Foo", :bar => :references, :special_bar => :references do
-        belongs_to :bar
-      end
-      create_model "Bar" do
-        has_many :foos, :foreign_key => :special_bar_id
-      end
-
-      assert_equal [Domain::Relationship] * 2, Domain.generate.relationships.collect(&:class)
+    create_model "Foo", :bar => :references, :special_bar => :references do
+      belongs_to :bar
     end
+    create_model "Bar" do
+      has_many :foos, :foreign_key => :special_bar_id
+    end
+
+    assert_equal [Domain::Relationship] * 2, Domain.generate.relationships.collect(&:class)
   end
 
   test "relationships should use model name first in alphabet as source for many to many relationships" do

--- a/test/unit/graphviz_test.rb
+++ b/test/unit/graphviz_test.rb
@@ -314,21 +314,16 @@ class GraphvizTest < ActiveSupport::TestCase
   end
 
   test "generate should create edge for each relationship" do
-    # TODO: Once we drop Rails 3.2 support, we _should_ be able to drop the
-    #   :respond_to? check
-    #
-    if respond_to? :skip
-      skip("multiple edges between the same objects can cause segfaults in some versions of Graphviz")
+    skip("multiple edges between the same objects can cause segfaults in some versions of Graphviz")
 
-      create_model "Foo", :bar => :references do
-        belongs_to :bar
-      end
-      create_model "Bar", :foo => :references do
-        belongs_to :foo
-      end
-
-      assert_equal [["m_Bar", "m_Foo"], ["m_Foo", "m_Bar"]], find_dot_node_pairs(diagram).sort
+    create_model "Foo", :bar => :references do
+      belongs_to :bar
     end
+    create_model "Bar", :foo => :references do
+      belongs_to :foo
+    end
+
+    assert_equal [["m_Bar", "m_Foo"], ["m_Foo", "m_Bar"]], find_dot_node_pairs(diagram).sort
   end
 
   test "generate should create edge to polymorphic entity if polymorphism is true" do


### PR DESCRIPTION
## Summary

Updates the gemspec to reflect the actual minimum supported versions and removes legacy Rails 3.2 compatibility code.

## Changes

### Gemspec
- **Ruby**: `>= 2.2` → `>= 3.1`
- **ActiveRecord**: `>= 4.2` → `>= 7.0`
- **ActiveSupport**: `>= 4.2` → `>= 7.0`

### Test cleanup
- Removed `respond_to?(:skip)` checks in 2 test files
- Removed TODO comments about Rails 3.2 support
- The `skip` method has been available in Minitest for many years

## Why

The gemspec claimed support for Ruby 2.2 and Rails 4.2, but:
1. CI only tests Ruby 3.1+ and Rails 7.0+
2. Ruby 2.2 reached EOL in 2018
3. Rails 4.2 reached EOL in 2017
4. The README now states Ruby 3.1+ and Rails 7.0+ (updated in #430)

This brings the gemspec in line with reality and removes dead code.

## Testing

All tests pass (323 runs, 2 skips, 1 unrelated font-name failure on macOS).