### PR TITLE
Add table_names and native_types options

### DIFF
--- a/lib/rails_erd.rb
+++ b/lib/rails_erd.rb
@@ -58,6 +58,8 @@ module RailsERD
         :only_recursion_depth, nil,
         :prepend_primary, false,
         :cluster, false,
+        :table_names, false,
+        :native_types, false
       ]
     end
 

--- a/lib/rails_erd/cli.rb
+++ b/lib/rails_erd/cli.rb
@@ -87,6 +87,16 @@ Choice.options do
     desc "Control how edges are represented. See http://www.graphviz.org/doc/info/attrs.html#d:splines for values."
   end
 
+  option :table_names do
+    long "--table_names=BOOLEAN"
+    desc "Label each entity with the table name instead of the ActiveRecord class name."
+  end
+
+  option :native_types do
+    long "--native_types=BOOLEAN"
+    desc "Display the db-native types instead of the Rails migration ones."
+  end
+
   separator ""
   separator "Output options:"
 

--- a/lib/rails_erd/diagram/templates/node.html.erb
+++ b/lib/rails_erd/diagram/templates/node.html.erb
@@ -1,6 +1,6 @@
 <% if options.orientation == :horizontal %>{<% end %>
 <table border="0" align="center" cellspacing="0.5" cellpadding="0" width="<%= NODE_WIDTH + 4 %>">
-  <tr><td align="center" valign="bottom" width="<%= NODE_WIDTH %>"><font face="<%= FONTS[:bold] %>" point-size="11"><%= entity.name %></font></td></tr>
+  <tr><td align="center" valign="bottom" width="<%= NODE_WIDTH %>"><font face="<%= FONTS[:bold] %>" point-size="11"><%= entity.label %></font></td></tr>
 </table>
 <% if attributes.any? %>
 |

--- a/lib/rails_erd/diagram/templates/node.record.erb
+++ b/lib/rails_erd/diagram/templates/node.record.erb
@@ -1,4 +1,4 @@
-<% if options.orientation == :horizontal %>{<% end %><%= entity.name %><% if attributes.any? %>
+<% if options.orientation == :horizontal %>{<% end %><%= entity.label %><% if attributes.any? %>
 |<%  attributes.each do |attribute| %><%=
        attribute %> (<%= attribute.type_description %>)
 <%   end %><% end %><% if options.orientation == :horizontal %>}<% end %>

--- a/lib/rails_erd/domain/attribute.rb
+++ b/lib/rails_erd/domain/attribute.rb
@@ -49,7 +49,7 @@ module RailsERD
       # The type of the attribute, equal to the Rails migration type. Can be any
       # of +:string+, +:integer+, +:boolean+, +:text+, etc.
       def type
-        column.type or column.sql_type.downcase.to_sym
+        !RailsERD.options[:native_types] and column.type or column.sql_type.downcase.to_sym
       end
 
       # Returns +true+ if this attribute is a content column, that is, if it

--- a/lib/rails_erd/domain/attribute.rb
+++ b/lib/rails_erd/domain/attribute.rb
@@ -129,6 +129,7 @@ module RailsERD
       # <tt>:boolean, :null => false</tt>:: boolean *
       def type_description
         type.to_s.dup.tap do |desc|
+          desc << "[]" if column.respond_to?(:array?) && column.array?
           desc << " #{limit_description}" if limit_description
           desc << " ∗" if mandatory? && !primary_key? # Add a hair space + low asterisk (Unicode characters)
           desc << " U" if unique? && !primary_key? && !foreign_key? # Add U if unique but non-key

--- a/lib/rails_erd/domain/entity.rb
+++ b/lib/rails_erd/domain/entity.rb
@@ -40,6 +40,10 @@ module RailsERD
         @domain, @name, @model = domain, name, model
       end
 
+      def label
+        RailsERD.options[:table_names] ? model.table_name : name
+      end
+
       # Returns an array of attributes for this entity.
       def attributes
         @attributes ||= generalized? ? [] : Attribute.from_model(domain, model)


### PR DESCRIPTION
## Summary

Adds two new CLI options for customizing diagram output:
- `--table_names` - Display database table names instead of ActiveRecord model class names
- `--native_types` - Display native database column types instead of Rails migration types

Also adds array type annotation (`[]`) for PostgreSQL array columns.

## Changes

- Add `table_names` and `native_types` options to `RailsERD.options`
- Add CLI flags for both options
- Add `Entity#label` method that returns table name or model name based on option
- Update templates to use `entity.label` instead of `entity.name`
- Modify `Attribute#type` to return native SQL type when `native_types` is enabled
- Add array type indicator in `type_description`

## Fix Applied

Fixed `column.array?` call to use `respond_to?` check since this method is PostgreSQL-specific and doesn't exist on SQLite3 columns.

## Credits

Based on PR #415 by @bendilley - rebased on current master and fixed SQLite3 compatibility.

## Testing

All tests pass (323 runs, 1 unrelated font-name failure on macOS).