### PR TITLE
Add ostruct as runtime dependency for Ruby 3.5 compatibility

### DIFF
--- a/rails-erd.gemspec
+++ b/rails-erd.gemspec
@@ -17,6 +17,7 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency "activesupport", ">= 7.0"
   s.add_runtime_dependency "ruby-graphviz", "~> 1.2"
   s.add_runtime_dependency "choice", "~> 0.2.0"
+  s.add_runtime_dependency "ostruct" # Required as of Ruby 3.5 (no longer in stdlib)
 
   s.add_development_dependency "pry"
   s.add_development_dependency "pry-nav"


### PR DESCRIPTION
## Summary

Adds `ostruct` as an explicit runtime dependency to ensure compatibility with Ruby 3.5+.

## Why

The `ostruct` gem will be removed from Ruby's standard library starting with Ruby 3.5.0. Currently, `pry` (a development dependency) loads `ostruct`, which triggers a deprecation warning on Ruby 3.4:

```
warning: ostruct was loaded from the standard library, but will no longer be part of the default gems starting from Ruby 3.5.0.
```

Adding it as an explicit dependency silences the warning now and prevents breakage when Ruby 3.5 is released.

## Testing

All tests pass (323 runs, 1 unrelated font-name failure on macOS).

Fixes #424