### PR TITLE
Add Rails 8 Solid* models to rails_models list

### DIFF
--- a/lib/rails_erd/domain.rb
+++ b/lib/rails_erd/domain.rb
@@ -132,12 +132,25 @@ module RailsERD
     def rails_models
       %w(
         ActionMailbox::InboundEmail
+        ActionText::EncryptedRichText
+        ActionText::RichText
         ActiveStorage::Attachment
         ActiveStorage::Blob
         ActiveStorage::VariantRecord
-        ActionText::RichText
-        ActionText::EncryptedRichText
-      ).map{ |model| Object.const_get(model) rescue nil }.compact
+        SolidCable::Message
+        SolidCache::Entry
+        SolidQueue::BlockedExecution
+        SolidQueue::ClaimedExecution
+        SolidQueue::FailedExecution
+        SolidQueue::Job
+        SolidQueue::Pause
+        SolidQueue::Process
+        SolidQueue::ReadyExecution
+        SolidQueue::RecurringExecution
+        SolidQueue::RecurringTask
+        SolidQueue::ScheduledExecution
+        SolidQueue::Semaphore
+      ).map { |model| Object.const_get(model) rescue nil }.compact
     end
 
     def tableless_rails_models


### PR DESCRIPTION
## Summary

Add SolidCable, SolidCache, and SolidQueue models to the list of internal Rails models that are automatically filtered out when their tables don't exist.

## Problem

Rails 8 introduced new internal models for SolidCable, SolidCache, and SolidQueue. When these gems are installed but their migrations haven't been run (or they use a separate database), rails-erd produces noisy warnings:

```
Warning: Ignoring invalid model SolidCable::Message (table solid_cable_messages does not exist)
Warning: Ignoring invalid model SolidCache::Entry (table solid_cache_entries does not exist)
Warning: Ignoring invalid model SolidQueue::Job (table solid_queue_jobs does not exist)
...
```

## Solution

Add these models to the `rails_models` list, which is used to filter out tableless Rails internal models before validity checks run.

Models added:
- `SolidCable::Message`
- `SolidCache::Entry`
- `SolidQueue::BlockedExecution`
- `SolidQueue::ClaimedExecution`
- `SolidQueue::FailedExecution`
- `SolidQueue::Job`
- `SolidQueue::Pause`
- `SolidQueue::Process`
- `SolidQueue::ReadyExecution`
- `SolidQueue::RecurringExecution`
- `SolidQueue::RecurringTask`
- `SolidQueue::ScheduledExecution`
- `SolidQueue::Semaphore`

Fixes #423

---

**Note:** A separate PR will address the secondary issue mentioned in #423 - that the `exclude` config option doesn't suppress warnings for excluded models.