### PR TITLE
Suppress warnings for models in exclude config

### DIFF
--- a/lib/rails_erd/domain.rb
+++ b/lib/rails_erd/domain.rb
@@ -178,7 +178,13 @@ module RailsERD
         raise "table #{model.table_name} does not exist"
       end
     rescue => e
-      warn "Ignoring invalid model #{model.name} (#{e.message})"
+      warn "Ignoring invalid model #{model.name} (#{e.message})" unless excluded_model?(model)
+    end
+
+    def excluded_model?(model)
+      return false unless options.exclude.present?
+
+      [options.exclude].flatten.map(&:to_sym).include?(model.name.to_sym)
     end
 
     def check_association_validity(association)
@@ -192,7 +198,20 @@ module RailsERD
         entity_by_name(entity_name) or raise "model #{entity_name} exists, but is not included in domain"
       end
     rescue => e
-      warn "Ignoring invalid association #{association_description(association)} (#{e.message})"
+      warn "Ignoring invalid association #{association_description(association)} (#{e.message})" unless excluded_association?(association)
+    end
+
+    def excluded_association?(association)
+      return false unless options.exclude.present?
+
+      excluded_names = [options.exclude].flatten.map(&:to_sym)
+
+      # Suppress warning if either the source model or target model is excluded
+      excluded_names.include?(association.active_record.name.to_sym) ||
+        (association.klass.name && excluded_names.include?(association.klass.name.to_sym))
+    rescue NameError
+      # If we can't determine the target class, check only the source model
+      excluded_names.include?(association.active_record.name.to_sym)
     end
 
     def check_polymorphic_association_validity(association)


### PR DESCRIPTION
## Summary

When a model is listed in the `exclude` configuration option, don't print 'Ignoring invalid model' or 'Ignoring invalid association' warnings for it.

## Problem

As reported in #423, the `exclude` config option only filters models from the final diagram output, but warnings are still printed during domain construction:

```yaml
# .erdconfig
exclude:
  - SolidQueue::Job
  - SolidCache::Entry
```

```
# Still prints warnings even though models are excluded!
Warning: Ignoring invalid model SolidQueue::Job (table solid_queue_jobs does not exist)
Warning: Ignoring invalid association :job on SolidQueue::Execution (model SolidQueue::Job exists, but is not included in domain)
```

This is confusing because users expect excluding a model to silence all output related to it.

## Solution

Suppress warnings for:
- Models explicitly listed in `exclude`
- Associations where either the source or target model is excluded

This is a companion PR to #437 which adds Solid* models to the default exclusion list. Together they fully address #423:
- #437 - Adds Solid* models to auto-excluded Rails models (no config needed)
- This PR - Makes the `exclude` config actually suppress warnings (for any model)

## Testing

Existing tests pass. The font-related test failure is pre-existing and unrelated to these changes.