### PR TITLE
Add SolidQueue::Execution to rails_models list

### DIFF
--- a/lib/rails_erd/domain.rb
+++ b/lib/rails_erd/domain.rb
@@ -141,6 +141,7 @@ module RailsERD
         SolidCache::Entry
         SolidQueue::BlockedExecution
         SolidQueue::ClaimedExecution
+        SolidQueue::Execution
         SolidQueue::FailedExecution
         SolidQueue::Job
         SolidQueue::Pause


### PR DESCRIPTION
## Summary

Add the missing `SolidQueue::Execution` model to the rails_models list.

## Problem

After #437 was merged, testing revealed one remaining warning:

```
Warning: Ignoring invalid association :job on SolidQueue::Execution (model SolidQueue::Job exists, but is not included in domain)
```

This happens because `SolidQueue::Execution` is a concrete model (not abstract) that has an association to `SolidQueue::Job`. Since `Job` is filtered out but `Execution` wasn't, the association warning was still printed.

## Solution

Add `SolidQueue::Execution` to the rails_models list alongside the other SolidQueue models.

## Testing

Tested locally with a Rails 8 app with solid_queue, solid_cache, and solid_cable installed:

```
$ bundle exec rake erd
Loading application environment...
Loading code in search of Active Record models...
Generating Entity-Relationship Diagram for 29 models...
Done! Saved diagram to ./erd.pdf
```

No warnings! ✅