### PR TITLE
Fix NoMethodError when relationship destination is nil

### DIFF
--- a/lib/rails_erd/diagram/graphviz.rb
+++ b/lib/rails_erd/diagram/graphviz.rb
@@ -239,6 +239,8 @@ module RailsERD
 
       each_relationship do |relationship|
         from, to = relationship.source, relationship.destination
+        next unless from && to
+
         unless draw_edge from.name, to.name, relationship_options(relationship)
           from.children.each do |child|
             draw_edge child.name, to.name, relationship_options(relationship)

--- a/lib/rails_erd/diagram/mermaid.rb
+++ b/lib/rails_erd/diagram/mermaid.rb
@@ -32,6 +32,8 @@ module RailsERD
 
       each_relationship do |relationship|
         from, to = relationship.source, relationship.destination
+        next unless from && to
+
         graph << "\t`#{from.name}` #{relation_arrow(relationship)} `#{to.name}`"
 
         from.children.each do |child|

--- a/lib/rails_erd/domain.rb
+++ b/lib/rails_erd/domain.rb
@@ -67,7 +67,9 @@ module RailsERD
 
     # Returns all relationships in your domain model.
     def relationships
-      @relationships ||= Relationship.from_associations(self, associations)
+      @relationships ||= Relationship.from_associations(self, associations).select do |relationship|
+        relationship.source && relationship.destination
+      end
     end
 
     # Returns all specializations in your domain model.


### PR DESCRIPTION
## Summary

Fix `NoMethodError: undefined method 'name' for nil:NilClass` that occurs when a relationship has a nil destination (or source).

## Problem

When using rails-erd with certain gems like PaperTrail, some models may have associations to other models that are excluded from the domain (e.g., version models without tables). This causes `relationship.destination` to be `nil`, leading to a crash:

```ruby
# From issue #411
relationship.destination
=> nil

relationship.destination.name
NoMethodError: undefined method 'name' for nil:NilClass
```

The error occurs in:
- `Domain#relationships_mapping` (line 110)
- `Diagram::Graphviz` each_relationship block (line 242)
- `Diagram::Mermaid` each_relationship block (line 35)

## Solution

Two-part fix:

1. **Filter at the source** - In `Domain#relationships`, filter out relationships where `source` or `destination` is nil before they're used anywhere

2. **Defensive guards** - Add `next unless from && to` guards in both Graphviz and Mermaid generators as a safety net

## Testing

All existing tests pass (the font test failure is pre-existing and unrelated).

Fixes #411

## Related

This issue was reported with PaperTrail but could affect any setup where:
- A model has an association to another model
- The target model is excluded from the domain (no table, filtered out, etc.)
- The association is still detected by ActiveRecord reflection