### PR TITLE
Fix --only with single model and --only_recursion_depth

### DIFF
--- a/lib/rails_erd/diagram.rb
+++ b/lib/rails_erd/diagram.rb
@@ -128,8 +128,10 @@ module RailsERD
       instance_eval(&callbacks[:setup])
       if options.only_recursion_depth.present?
         depth = options.only_recursion_depth.to_s.to_i
+        # Ensure options[:only] is an array (CLI may pass a single string)
+        options[:only] = [options[:only]].flatten
         options[:only].dup.each do |class_name|
-          options[:only]+= recurse_into_relationships(@domain.entity_by_name(class_name), depth)
+          options[:only] += recurse_into_relationships(@domain.entity_by_name(class_name), depth)
         end
         options[:only].uniq!
       end


### PR DESCRIPTION
## Summary

Fix `NoMethodError: undefined method 'each' for "ModelName":String` when using `--only` with a single model name and `--only_recursion_depth`.

## Problem

When using the CLI with a single model:

```bash
erd --only ModelName --only_recursion_depth=1
```

The `options[:only]` value is a string (`"ModelName"`) rather than an array. The code at line 131 calls `.dup.each` on it, which fails because String doesn't have an `each` method:

```
NoMethodError: undefined method 'each' for "ModelName":String
    from lib/rails_erd/diagram.rb:131:in 'generate'
```

## Solution

Ensure `options[:only]` is always an array before iterating, using the same `[value].flatten` pattern already used elsewhere in the codebase (line 183).

## Testing

All existing tests pass (the font test failure is pre-existing and unrelated).

Fixes #376