### PR TITLE
feat: Add erDiagram style for Mermaid output

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,7 @@ filetype: pdf
 indirect: true
 inheritance: false
 markup: true
+mermaid_style: classdiagram
 notation: simple
 orientation: horizontal
 polymorphism: false
@@ -88,6 +89,44 @@ Or via command line:
 
 ```bash
 bundle exec erd filename="docs/erd"
+```
+
+Mermaid output
+--------------
+
+Rails ERD can generate [Mermaid](https://mermaid.js.org/) diagrams instead of Graphviz:
+
+```bash
+bundle exec erd generator=mermaid
+```
+
+By default, Mermaid output uses `classDiagram` syntax. You can switch to the more traditional `erDiagram` syntax with crow's foot notation:
+
+```bash
+bundle exec erd generator=mermaid mermaid_style=erdiagram
+```
+
+Or in your `.erdconfig`:
+
+```yaml
+generator: mermaid
+mermaid_style: erdiagram
+```
+
+The `erDiagram` style produces output like:
+
+```mermaid
+erDiagram
+  User {
+    integer id PK
+    string name
+    integer organization_id FK
+  }
+  Organization {
+    integer id PK
+    string name
+  }
+  Organization ||--o{ User : ""
 ```
 
 Auto generation

--- a/lib/rails_erd.rb
+++ b/lib/rails_erd.rb
@@ -47,6 +47,7 @@ module RailsERD
         :indirect, true,
         :inheritance, false,
         :markup, true,
+        :mermaid_style, :classdiagram,
         :notation, :simple,
         :orientation, :horizontal,
         :polymorphism, false,

--- a/lib/rails_erd/cli.rb
+++ b/lib/rails_erd/cli.rb
@@ -12,6 +12,11 @@ Choice.options do
     desc "Generator to use (graphviz or mermaid). Defaults to graphviz."
   end
 
+  option :mermaid_style do
+    long "--mermaid_style=STYLE"
+    desc "Mermaid diagram style: classdiagram (default) or erdiagram. Only applies when generator is mermaid."
+  end
+
   option :title do
     long "--title=TITLE"
     desc "Replace default diagram title with a custom one."

--- a/lib/rails_erd/config.rb
+++ b/lib/rails_erd/config.rb
@@ -66,7 +66,7 @@ module RailsERD
         end
 
       # <symbol>
-      when :filetype, :notation, :generator
+      when :filetype, :notation, :generator, :mermaid_style
         value.to_sym
 
       # [<string>]

--- a/lib/rails_erd/diagram/mermaid.rb
+++ b/lib/rails_erd/diagram/mermaid.rb
@@ -10,38 +10,65 @@ module RailsERD
       attr_accessor :graph
 
       setup do
-        self.graph = ["classDiagram"]
+        self.graph = [diagram_type]
 
         # hard code to RL to make it easier to view diagrams from GitHub
         self.graph << "\tdirection RL"
       end
 
       each_entity do |entity, attributes|
-        graph << "\tclass `#{entity}`"
-
-        attributes.each do | attr|
-          graph << "\t`#{entity}` : +#{attr.type} #{attr.name}"
+        if er_diagram?
+          # Build entity block as a single string to avoid uniq issues with closing braces
+          entity_lines = ["\t#{entity} {"]
+          attributes.each do |attr|
+            key_marker = attribute_key_marker(attr)
+            entity_lines << "\t\t#{attr.type} #{attr.name}#{key_marker}"
+          end
+          entity_lines << "\t}"
+          graph << entity_lines.join("\n")
+        else
+          graph << "\tclass `#{entity}`"
+          attributes.each do |attr|
+            graph << "\t`#{entity}` : +#{attr.type} #{attr.name}"
+          end
         end
       end
 
       each_specialization do |specialization|
         from, to = specialization.generalized, specialization.specialized
-        graph << "\t<<polymorphic>> `#{specialization.generalized}`"
-        graph << "\t #{from.name} <|-- #{to.name}"
+        if er_diagram?
+          # erDiagram doesn't have a direct polymorphic notation, use inheritance-like
+          graph << "\t#{from.name} ||--o{ #{to.name} : \"specializes\""
+        else
+          graph << "\t<<polymorphic>> `#{specialization.generalized}`"
+          graph << "\t #{from.name} <|-- #{to.name}"
+        end
       end
 
       each_relationship do |relationship|
         from, to = relationship.source, relationship.destination
         next unless from && to
 
-        graph << "\t`#{from.name}` #{relation_arrow(relationship)} `#{to.name}`"
+        if er_diagram?
+          graph << "\t#{from.name} #{er_relation_notation(relationship)} #{to.name} : \"\""
 
-        from.children.each do |child|
-          graph << "\t`#{child.name}` #{relation_arrow(relationship)} `#{to.name}`"
-        end
+          from.children.each do |child|
+            graph << "\t#{child.name} #{er_relation_notation(relationship)} #{to.name} : \"\""
+          end
 
-        to.children.each do |child|
-          graph << "\t`#{from.name}` #{relation_arrow(relationship)} `#{child.name}`"
+          to.children.each do |child|
+            graph << "\t#{from.name} #{er_relation_notation(relationship)} #{child.name} : \"\""
+          end
+        else
+          graph << "\t`#{from.name}` #{relation_arrow(relationship)} `#{to.name}`"
+
+          from.children.each do |child|
+            graph << "\t`#{child.name}` #{relation_arrow(relationship)} `#{to.name}`"
+          end
+
+          to.children.each do |child|
+            graph << "\t`#{from.name}` #{relation_arrow(relationship)} `#{child.name}`"
+          end
         end
       end
 
@@ -56,6 +83,49 @@ module RailsERD
         "#{options.filename}.mmd"
       end
 
+      def diagram_type
+        er_diagram? ? "erDiagram" : "classDiagram"
+      end
+
+      def er_diagram?
+        options[:mermaid_style] == :erdiagram || options[:mermaid_style] == :er
+      end
+
+      # erDiagram relationship notation using crow's foot
+      # Format: left_cardinality--right_cardinality
+      # Cardinality markers:
+      #   || = exactly one
+      #   o| = zero or one
+      #   }| = one or more
+      #   }o = zero or more
+      def er_relation_notation(relationship)
+        line = relationship.indirect? ? ".." : "--"
+
+        # Left side (source cardinality - how many source entities relate to one destination)
+        left = if relationship.many_to?
+          relationship.source_optional? ? "o{" : "|{"
+        else
+          relationship.source_optional? ? "o|" : "||"
+        end
+
+        # Right side (destination cardinality - how many destination entities relate to one source)
+        right = if relationship.to_many?
+          relationship.destination_optional? ? "}o" : "}|"
+        else
+          relationship.destination_optional? ? "|o" : "||"
+        end
+
+        "#{left}#{line}#{right}"
+      end
+
+      def attribute_key_marker(attr)
+        markers = []
+        markers << "PK" if attr.primary_key?
+        markers << "FK" if attr.foreign_key?
+        markers.empty? ? "" : " #{markers.join(',')}"
+      end
+
+      # classDiagram relationship arrows (legacy)
       def relation_arrow(relationship)
         arrow_body = arrow_body relationship
         arrow_head = arrow_head relationship

--- a/test/unit/mermaid_test.rb
+++ b/test/unit/mermaid_test.rb
@@ -280,4 +280,101 @@ class MermaidTest < ActiveSupport::TestCase
 
     assert_equal expected, diagram.graph.uniq
   end
+
+  # erDiagram tests ============================================================
+
+  test "erdiagram style should use erDiagram header" do
+    create_simple_domain
+
+    result = diagram(:mermaid_style => :erdiagram).graph.uniq
+
+    assert_equal "erDiagram", result[0]
+    assert_equal "\tdirection RL", result[1]
+    # Entity blocks are joined with newlines
+    assert result.any? { |line| line.include?("Bar {") }
+    assert result.any? { |line| line.include?("Beer {") }
+    # Relationship uses crow's foot notation
+    assert result.any? { |line| line.include?("Bar") && line.include?("Beer") && line.include?("--") }
+  end
+
+  test "erdiagram style should include attributes with PK/FK markers" do
+    create_model "Foo", :bar => :references, :column => :string do
+      belongs_to :bar
+    end
+
+    create_model "Bar", :column => :string
+
+    result = diagram(:mermaid_style => :erdiagram, :attributes => [:primary_keys, :foreign_keys, :content]).graph.join("\n")
+
+    assert result.include?("erDiagram")
+    assert result.include?("id PK"), "Should include primary key marker"
+    assert result.include?("bar_id FK"), "Should include foreign key marker"
+  end
+
+  test "erdiagram style should use crow's foot notation for one to many" do
+    create_one_to_many_assoc_domain
+
+    result = diagram(:mermaid_style => :erdiagram).graph.uniq
+
+    assert result.include?("erDiagram")
+    # One to many should have }| or }o on the "many" side
+    relationship_line = result.find { |line| line.include?("One") && line.include?("Many") && line.include?("--") }
+    assert relationship_line, "Should have a relationship line between One and Many"
+    assert relationship_line.match?(/\}\||\}o/), "Should use crow's foot notation for many side"
+  end
+
+  test "erdiagram style should use crow's foot notation for many to many" do
+    create_many_to_many_assoc_domain
+
+    result = diagram(:mermaid_style => :erdiagram).graph.uniq
+
+    assert result.include?("erDiagram")
+    # Many to many should have }| or }o on both sides
+    relationship_line = result.find { |line| line.include?("Many") && line.include?("More") && line.include?("--") }
+    assert relationship_line, "Should have a relationship line between Many and More"
+  end
+
+  test "erdiagram style should use crow's foot notation for one to one" do
+    create_one_to_one_assoc_domain
+
+    result = diagram(:mermaid_style => :erdiagram).graph.uniq
+
+    assert result.any? { |line| line.include?("erDiagram") }
+    # One to one should have | on both sides (not })
+    relationship_line = result.find { |line| line.include?("One") && line.include?("Other") && line.include?("--") }
+    assert relationship_line, "Should have a relationship line between One and Other"
+    # Should not have } which indicates "many"
+    refute relationship_line.include?("}"), "One-to-one should not use } (many) notation: #{relationship_line}"
+  end
+
+  test "erdiagram style should use dotted line for indirect relationships" do
+    create_model "Foo" do
+      has_many :bazs
+      has_many :bars
+    end
+
+    create_model "Bar", :foo => :references do
+      belongs_to :foo
+      has_many :bazs, :through => :foo
+    end
+
+    create_model "Baz", :foo => :references do
+      belongs_to :foo
+    end
+
+    result = diagram(:mermaid_style => :erdiagram).graph.uniq
+
+    # Indirect relationship should use .. instead of --
+    indirect_line = result.find { |line| line.include?("Bar") && line.include?("Baz") }
+    assert indirect_line, "Should have a relationship line between Bar and Baz"
+    assert indirect_line.include?(".."), "Indirect relationship should use dotted line"
+  end
+
+  test "er option alias should work same as erdiagram" do
+    create_simple_domain
+
+    result = diagram(:mermaid_style => :er).graph
+
+    assert result.include?("erDiagram")
+  end
 end


### PR DESCRIPTION
## Summary

This PR adds support for Mermaid's `erDiagram` syntax as an alternative to the default `classDiagram` style, as requested in #410.

## Changes

### New `mermaid_style` option

- `classdiagram` (default): Uses Mermaid classDiagram syntax (existing behavior)
- `erdiagram` or `er`: Uses Mermaid erDiagram syntax with crow's foot notation

### erDiagram features

- **Crow's foot cardinality markers**: `||`, `o|`, `}|`, `}o` for proper ER notation
- **PK/FK attribute markers**: Attributes show `PK` for primary keys and `FK` for foreign keys
- **Entity blocks**: Attributes are grouped inside curly braces
- **Relationship labels**: Empty labels are included (required by erDiagram syntax)

## Usage

Command line:
```bash
bundle exec erd generator=mermaid mermaid_style=erdiagram
```

Or in `.erdconfig`:
```yaml
generator: mermaid
mermaid_style: erdiagram
```

## Example output

```mermaid
erDiagram
  User {
    integer id PK
    string name
    integer organization_id FK
  }
  Organization {
    integer id PK
    string name
  }
  Organization ||--o{ User : ""
```

## Closes

Closes #410