### PR TITLE
fix: Use hash access for options in CLI

### DIFF
--- a/lib/rails_erd/cli.rb
+++ b/lib/rails_erd/cli.rb
@@ -176,7 +176,7 @@ module RailsERD
 
     def initialize(path, options)
       @path, @options = path, options
-      require "rails_erd/diagram/graphviz" if options.generator == :graphviz
+      require "rails_erd/diagram/graphviz" if options[:generator] == :graphviz
     end
 
     def start
@@ -214,7 +214,7 @@ module RailsERD
     end
 
     def generator
-      if options.generator == :mermaid
+      if options[:generator] == :mermaid
         RailsERD::Diagram::Mermaid
       else
         RailsERD::Diagram::Graphviz


### PR DESCRIPTION
## Summary

Fixes a bug in the CLI where `options.generator` was used instead of `options[:generator]`. The `options` variable is a Hash, not an OpenStruct, so method-style access doesn't work.

## Problem

When running `bundle exec erd generator=mermaid`, the CLI would fail with:

```
undefined method 'generator' for an instance of Hash (NoMethodError)
```

## Solution

Use bracket notation (`options[:generator]`) instead of method notation (`options.generator`).