### PR TITLE
fix: Convert CLI string options to symbols like rake task

### DIFF
--- a/lib/rails_erd/cli.rb
+++ b/lib/rails_erd/cli.rb
@@ -160,16 +160,22 @@ module RailsERD
   class CLI
     attr_reader :path, :options
 
+    # Options that should be converted to symbols
+    SYMBOL_OPTIONS = %i[generator mermaid_style filetype notation orientation].freeze
+
     class << self
       def start
         path = Choice.rest.first || Dir.pwd
         options = Choice.choices.each_with_object({}) do |(key, value), opts|
+          key_sym = key.to_sym
           if key.start_with? "no_"
             opts[key.gsub("no_", "").to_sym] = !value
           elsif value.to_s.include? ","
-            opts[key.to_sym] = value.split(",").map(&:to_s)
+            opts[key_sym] = value.split(",").map(&:to_s)
+          elsif SYMBOL_OPTIONS.include?(key_sym) && value.is_a?(String)
+            opts[key_sym] = value.to_sym
           else
-            opts[key.to_sym] = value
+            opts[key_sym] = value
           end
         end
         if options[:config_file] && options[:config_file] != ''
@@ -181,7 +187,11 @@ module RailsERD
 
     def initialize(path, options)
       @path, @options = path, options
-      require "rails_erd/diagram/graphviz" if options[:generator] == :graphviz
+      if options[:generator] == :mermaid
+        require "rails_erd/diagram/mermaid"
+      else
+        require "rails_erd/diagram/graphviz"
+      end
     end
 
     def start

--- a/test/unit/cli_test.rb
+++ b/test/unit/cli_test.rb
@@ -1,0 +1,74 @@
+require File.expand_path("../test_helper", File.dirname(__FILE__))
+require "rails_erd/cli"
+
+class CLITest < ActiveSupport::TestCase
+  def setup
+    RailsERD.options.filetype = :dot
+    RailsERD.options.warn = false
+  end
+
+  # Generator selection ========================================================
+  test "CLI should use graphviz generator by default" do
+    cli = RailsERD::CLI.new(Dir.pwd, {})
+    assert_equal RailsERD::Diagram::Graphviz, cli.send(:generator)
+  end
+
+  test "CLI should use mermaid generator when generator option is symbol" do
+    require "rails_erd/diagram/mermaid"
+    cli = RailsERD::CLI.new(Dir.pwd, { generator: :mermaid })
+    assert_equal RailsERD::Diagram::Mermaid, cli.send(:generator)
+  end
+
+  test "CLI should use graphviz generator when generator option is graphviz symbol" do
+    cli = RailsERD::CLI.new(Dir.pwd, { generator: :graphviz })
+    assert_equal RailsERD::Diagram::Graphviz, cli.send(:generator)
+  end
+
+  # Option parsing (SYMBOL_OPTIONS conversion) =================================
+  test "CLI start should convert generator string to symbol" do
+    # Simulate what Choice.choices returns (strings)
+    Choice.stubs(:choices).returns({ "generator" => "mermaid" })
+    Choice.stubs(:rest).returns([])
+
+    # Capture the options passed to new
+    captured_options = nil
+    RailsERD::CLI.stubs(:new).with do |path, options|
+      captured_options = options
+      true
+    end.returns(stub(start: nil))
+
+    RailsERD::CLI.start
+
+    assert_equal :mermaid, captured_options[:generator]
+  end
+
+  test "CLI start should convert mermaid_style string to symbol" do
+    Choice.stubs(:choices).returns({ "mermaid_style" => "erdiagram" })
+    Choice.stubs(:rest).returns([])
+
+    captured_options = nil
+    RailsERD::CLI.stubs(:new).with do |path, options|
+      captured_options = options
+      true
+    end.returns(stub(start: nil))
+
+    RailsERD::CLI.start
+
+    assert_equal :erdiagram, captured_options[:mermaid_style]
+  end
+
+  test "CLI start should convert filetype string to symbol" do
+    Choice.stubs(:choices).returns({ "filetype" => "pdf" })
+    Choice.stubs(:rest).returns([])
+
+    captured_options = nil
+    RailsERD::CLI.stubs(:new).with do |path, options|
+      captured_options = options
+      true
+    end.returns(stub(start: nil))
+
+    RailsERD::CLI.start
+
+    assert_equal :pdf, captured_options[:filetype]
+  end
+end


### PR DESCRIPTION
## Summary

Fixes the CLI to properly handle `--generator=mermaid` and `--mermaid_style=erdiagram` options.

## Problem

The CLI parses command-line options as strings, but the code expected symbols:

```ruby
# This fails because options[:generator] is "mermaid" (string), not :mermaid (symbol)
if options[:generator] == :mermaid
```

This caused:
- `--generator=mermaid` to fall back to Graphviz
- `--mermaid_style=erdiagram` to fall back to classDiagram

## Solution

Convert known symbol options to symbols at parse time, matching the behavior of the rake task (which already does this correctly):

```ruby
SYMBOL_OPTIONS = %i[generator mermaid_style filetype notation orientation].freeze

# In the options parsing loop:
elsif SYMBOL_OPTIONS.include?(key_sym) && value.is_a?(String)
  opts[key_sym] = value.to_sym
```

## Testing

```bash
bundle exec erd --generator=mermaid --mermaid_style=erdiagram
# Now correctly generates erDiagram output
```

Also adds CLI unit tests to prevent regression.