### PR TITLE
feat: Make Mermaid the default generator with erDiagram style

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,20 +24,26 @@ Requirements
 
 * Ruby 3.1+
 * ActiveRecord 7.0+
-* Graphviz 2.22+
+* Graphviz 2.22+ (optional - only needed for PDF/PNG output)
 
 Getting started
 ---------------
 
 See the [installation instructions](https://voormedia.github.io/rails-erd/install.html) for a complete description of how to install Rails ERD. Here's a summary:
 
-* Install Graphviz 2.22+ ([how?](https://voormedia.github.io/rails-erd/install.html)). On macOS with Homebrew run `brew install graphviz`.
-
-* on linux - `sudo apt-get install graphviz`
-
 * Add <tt>gem 'rails-erd', group: :development</tt> to your application's Gemfile
 
 * Run <tt>bundle exec erd</tt>
+
+This generates a Mermaid diagram (`erd.mmd`) by default. Mermaid diagrams render natively in GitHub, GitLab, and many documentation tools.
+
+**For PDF/PNG output (optional):**
+
+* Install Graphviz 2.22+ ([how?](https://voormedia.github.io/rails-erd/install.html)). On macOS with Homebrew run `brew install graphviz`, on Linux run `sudo apt-get install graphviz`.
+
+* Add `gem 'ruby-graphviz'` to your Gemfile
+
+* Run `bundle exec erd generator=graphviz filetype=pdf`
 
 ### Configuration
 
@@ -51,11 +57,12 @@ attributes:
   - content
 disconnected: true
 filename: erd
-filetype: pdf
+filetype: mmd
+generator: mermaid
 indirect: true
 inheritance: false
 markup: true
-mermaid_style: classdiagram
+mermaid_style: erdiagram
 notation: simple
 orientation: horizontal
 polymorphism: false
@@ -91,29 +98,24 @@ Or via command line:
 bundle exec erd filename="docs/erd"
 ```
 
-Mermaid output
---------------
+Mermaid output (default)
+------------------------
 
-Rails ERD can generate [Mermaid](https://mermaid.js.org/) diagrams instead of Graphviz:
+Rails ERD generates [Mermaid](https://mermaid.js.org/) diagrams by default. Mermaid is a text-based diagramming format that renders natively in GitHub, GitLab, Notion, and many other tools.
 
-```bash
-bundle exec erd generator=mermaid
-```
-
-By default, Mermaid output uses `classDiagram` syntax. You can switch to the more traditional `erDiagram` syntax with crow's foot notation:
+By default, Mermaid output uses `erDiagram` syntax with crow's foot notation, PK/FK markers, and proper cardinality. You can switch to `classDiagram` syntax if preferred:
 
 ```bash
-bundle exec erd generator=mermaid mermaid_style=erdiagram
+bundle exec erd mermaid_style=classdiagram
 ```
 
 Or in your `.erdconfig`:
 
 ```yaml
-generator: mermaid
-mermaid_style: erdiagram
+mermaid_style: classdiagram
 ```
 
-The `erDiagram` style produces output like:
+The default `erDiagram` style produces output like:
 
 ```mermaid
 erDiagram
@@ -129,6 +131,19 @@ erDiagram
   Organization ||--o{ User : ""
 ```
 
+Graphviz output
+---------------
+
+For PDF, PNG, or SVG output, you can use the Graphviz generator:
+
+```bash
+bundle exec erd generator=graphviz filetype=pdf
+```
+
+This requires:
+* The `ruby-graphviz` gem in your Gemfile
+* Graphviz installed on your system (`brew install graphviz` or `apt-get install graphviz`)
+
 Auto generation
 ---------------
 
@@ -141,12 +156,19 @@ Using in a gem (without Rails)
 If you want to use Rails ERD in a gem that defines ActiveRecord models but doesn't include Rails/Railties, you can use the API directly:
 
 ```ruby
-require 'rails_erd/diagram/graphviz'
+require 'rails_erd/diagram/mermaid'
 
 # Ensure your models are loaded
 require_relative 'lib/my_gem/models'
 
 # Generate the diagram
+RailsERD::Diagram::Mermaid.create
+```
+
+For Graphviz output:
+
+```ruby
+require 'rails_erd/diagram/graphviz'
 RailsERD::Diagram::Graphviz.create
 ```
 

--- a/erd.mmd
+++ b/erd.mmd
@@ -1,0 +1,7 @@
+erDiagram
+	direction TB
+	Bar {
+	}
+	Beer {
+	}
+	Bar o|--}o Beer : ""

--- a/lib/rails_erd.rb
+++ b/lib/rails_erd.rb
@@ -38,16 +38,16 @@ module RailsERD
 
     def default_options
       ActiveSupport::OrderedOptions[
-        :generator, :graphviz,
+        :generator, :mermaid,
         :attributes, :content,
         :disconnected, true,
         :filename, "erd",
-        :filetype, :pdf,
+        :filetype, :mmd,
         :fonts, {},
         :indirect, true,
         :inheritance, false,
         :markup, true,
-        :mermaid_style, :classdiagram,
+        :mermaid_style, :erdiagram,
         :notation, :simple,
         :orientation, :horizontal,
         :polymorphism, false,

--- a/lib/rails_erd/cli.rb
+++ b/lib/rails_erd/cli.rb
@@ -9,7 +9,7 @@ Choice.options do
 
   option :generator do
     long "--generator=Generator"
-    desc "Generator to use (graphviz or mermaid). Defaults to graphviz."
+    desc "Generator to use (mermaid or graphviz). Defaults to mermaid."
   end
 
   option :mermaid_style do
@@ -187,7 +187,8 @@ module RailsERD
 
     def initialize(path, options)
       @path, @options = path, options
-      if options[:generator] == :mermaid
+      generator = options[:generator] || RailsERD.options[:generator]
+      if generator == :mermaid
         require "rails_erd/diagram/mermaid"
       else
         require "rails_erd/diagram/graphviz"
@@ -229,7 +230,8 @@ module RailsERD
     end
 
     def generator
-      if options[:generator] == :mermaid
+      generator_type = options[:generator] || RailsERD.options[:generator]
+      if generator_type == :mermaid
         RailsERD::Diagram::Mermaid
       else
         RailsERD::Diagram::Graphviz

--- a/lib/rails_erd/diagram/graphviz.rb
+++ b/lib/rails_erd/diagram/graphviz.rb
@@ -1,20 +1,25 @@
 # frozen_string_literal: true
 
 require "rails_erd/diagram"
-require "graphviz"
 require "erb"
 
-# Fix bad RegEx test in Ruby-Graphviz.
-GraphViz::Types::LblString.class_eval do
-  def output # @private :nodoc:
-    if /^<.*>$/m =~ @data
-      @data
-    else
-      @data.to_s.inspect.gsub("\\\\", "\\")
+begin
+  require "graphviz"
+
+  # Fix bad RegEx test in Ruby-Graphviz.
+  GraphViz::Types::LblString.class_eval do
+    def output # @private :nodoc:
+      if /^<.*>$/m =~ @data
+        @data
+      else
+        @data.to_s.inspect.gsub("\\\\", "\\")
+      end
     end
+    alias_method :to_gv, :output
+    alias_method :to_s, :output
   end
-  alias_method :to_gv, :output
-  alias_method :to_s, :output
+rescue LoadError
+  # ruby-graphviz is optional as of v2.0 - only needed when using generator: graphviz
 end
 
 module RailsERD
@@ -182,6 +187,11 @@ module RailsERD
       attr_accessor :graph
 
       setup do
+        unless defined?(GraphViz)
+          raise LoadError, "The ruby-graphviz gem is required for Graphviz output. " \
+            "Add `gem 'ruby-graphviz'` to your Gemfile, or use `generator: mermaid` instead."
+        end
+
         self.graph = GraphViz.digraph(domain.name)
 
         # Set all default attributes.

--- a/lib/rails_erd/diagram/mermaid.rb
+++ b/lib/rails_erd/diagram/mermaid.rb
@@ -12,8 +12,9 @@ module RailsERD
       setup do
         self.graph = [diagram_type]
 
-        # hard code to RL to make it easier to view diagrams from GitHub
-        self.graph << "\tdirection RL"
+        # Respect orientation option: horizontal = TB (top-down), vertical = LR (left-right)
+        direction = (options.orientation.to_s == "vertical") ? "LR" : "TB"
+        self.graph << "\tdirection #{direction}"
       end
 
       each_entity do |entity, attributes|

--- a/lib/rails_erd/tasks.rake
+++ b/lib/rails_erd/tasks.rake
@@ -1,5 +1,3 @@
-require 'graphviz/utils'
-
 module ErdRakeHelper
   def say(message)
     puts message unless Rake.application.options.silent
@@ -9,10 +7,16 @@ end
 namespace :erd do
   task :check_dependencies do
     if RailsERD.options.generator == :graphviz
-      include GraphViz::Utils
-      unless find_executable("dot", nil)
-        raise "#{RailsERD.options.generator} Unable to find GraphViz's \"dot\" executable. Please " \
-              "visit https://voormedia.github.io/rails-erd/install.html for installation instructions."
+      begin
+        require 'graphviz/utils'
+        include GraphViz::Utils
+        unless find_executable("dot", nil)
+          raise "Unable to find GraphViz's \"dot\" executable. Please " \
+                "visit https://voormedia.github.io/rails-erd/install.html for installation instructions."
+        end
+      rescue LoadError
+        raise "The ruby-graphviz gem is required for Graphviz output. " \
+              "Add `gem 'ruby-graphviz'` to your Gemfile, or use `generator=mermaid` instead."
       end
     end
   end

--- a/rails-erd.gemspec
+++ b/rails-erd.gemspec
@@ -15,10 +15,12 @@ Gem::Specification.new do |s|
 
   s.add_runtime_dependency "activerecord", ">= 7.0"
   s.add_runtime_dependency "activesupport", ">= 7.0"
-  s.add_runtime_dependency "ruby-graphviz", "~> 1.2"
   s.add_runtime_dependency "choice", "~> 0.2.0"
   s.add_runtime_dependency "ostruct" # Required as of Ruby 3.5 (no longer in stdlib)
 
+  # ruby-graphviz is optional - only needed when using generator: graphviz
+  # As of v2.0, the default generator is mermaid which has no external dependencies
+  s.add_development_dependency "ruby-graphviz", "~> 1.2"
   s.add_development_dependency "pry"
   s.add_development_dependency "pry-nav"
 

--- a/test/unit/cli_test.rb
+++ b/test/unit/cli_test.rb
@@ -8,20 +8,21 @@ class CLITest < ActiveSupport::TestCase
   end
 
   # Generator selection ========================================================
-  test "CLI should use graphviz generator by default" do
-    cli = RailsERD::CLI.new(Dir.pwd, {})
-    assert_equal RailsERD::Diagram::Graphviz, cli.send(:generator)
-  end
-
-  test "CLI should use mermaid generator when generator option is symbol" do
+  test "CLI should use mermaid generator by default" do
     require "rails_erd/diagram/mermaid"
-    cli = RailsERD::CLI.new(Dir.pwd, { generator: :mermaid })
+    cli = RailsERD::CLI.new(Dir.pwd, {})
     assert_equal RailsERD::Diagram::Mermaid, cli.send(:generator)
   end
 
   test "CLI should use graphviz generator when generator option is graphviz symbol" do
     cli = RailsERD::CLI.new(Dir.pwd, { generator: :graphviz })
     assert_equal RailsERD::Diagram::Graphviz, cli.send(:generator)
+  end
+
+  test "CLI should use mermaid generator when generator option is mermaid symbol" do
+    require "rails_erd/diagram/mermaid"
+    cli = RailsERD::CLI.new(Dir.pwd, { generator: :mermaid })
+    assert_equal RailsERD::Diagram::Mermaid, cli.send(:generator)
   end
 
   # Option parsing (SYMBOL_OPTIONS conversion) =================================

--- a/test/unit/mermaid_test.rb
+++ b/test/unit/mermaid_test.rb
@@ -5,6 +5,7 @@ class MermaidTest < ActiveSupport::TestCase
   def setup
     RailsERD.options.filetype = :png
     RailsERD.options.warn     = false
+    RailsERD.options.mermaid_style = :classdiagram
   end
 
   def teardown
@@ -35,10 +36,17 @@ class MermaidTest < ActiveSupport::TestCase
     end
   end
 
-  test "direction should be right to left" do
+  test "direction should be top to bottom by default" do
     create_simple_domain
 
-    assert_equal "\tdirection RL", diagram.graph[1]
+    assert_equal "\tdirection TB", diagram.graph[1]
+  end
+
+  test "direction should be left to right when orientation is vertical" do
+    create_simple_domain
+
+    d = Diagram::Mermaid.new(Domain.generate, orientation: :vertical).tap { |diag| diag.generate }
+    assert_equal "\tdirection LR", d.graph[1]
   end
 
 
@@ -52,7 +60,7 @@ class MermaidTest < ActiveSupport::TestCase
 
     expected = [
       "classDiagram",
-      "\tdirection RL",
+      "\tdirection TB",
       "\tclass `Bar`",
       "\t`Bar` : +string column",
       "\tclass `Foo`",
@@ -68,7 +76,7 @@ class MermaidTest < ActiveSupport::TestCase
 
     expected = [
       "classDiagram",
-      "\tdirection RL",
+      "\tdirection TB",
       "\tclass `Bar`",
       "\tclass `Beer`",
       "\t`Bar` --> `Beer`"
@@ -109,7 +117,7 @@ class MermaidTest < ActiveSupport::TestCase
 
     expected = [
       "classDiagram",
-      "\tdirection RL",
+      "\tdirection TB",
       "\tclass `Bar`",
       "\t`Bar` : +string column",
       "\t`Bar` : +boolean column_two",
@@ -128,7 +136,7 @@ class MermaidTest < ActiveSupport::TestCase
 
     expected = [
       "classDiagram",
-      "\tdirection RL",
+      "\tdirection TB",
       "\tclass `Jar`",
       "\tclass `Lid`",
       "\t`Jar` --> `Lid`"
@@ -152,7 +160,7 @@ class MermaidTest < ActiveSupport::TestCase
 
     expected = [
       "classDiagram",
-      "\tdirection RL",
+      "\tdirection TB",
       "\tclass `Cannon`",
       "\tclass `Defensible`",
       "\tclass `Galleon`",
@@ -183,7 +191,7 @@ class MermaidTest < ActiveSupport::TestCase
 
     expected = [
       "classDiagram",
-      "\tdirection RL",
+      "\tdirection TB",
       "\tclass `Cannon`",
       "\tclass `Galleon`",
       "\tclass `Stronghold`",
@@ -199,7 +207,7 @@ class MermaidTest < ActiveSupport::TestCase
 
     expected = [
       "classDiagram",
-      "\tdirection RL",
+      "\tdirection TB",
       "\tclass `Many`",
       "\tclass `One`",
       "\t`One` --> `Many`"
@@ -225,7 +233,7 @@ class MermaidTest < ActiveSupport::TestCase
 
     expected = [
       "classDiagram",
-      "\tdirection RL",
+      "\tdirection TB",
       "\tclass `Bar`",
       "\tclass `Baz`",
       "\tclass `Foo`",
@@ -242,7 +250,7 @@ class MermaidTest < ActiveSupport::TestCase
 
     expected = [
       "classDiagram",
-      "\tdirection RL",
+      "\tdirection TB",
       "\tclass `Many`",
       "\tclass `More`",
       "\t`Many` <--> `More`"
@@ -256,7 +264,7 @@ class MermaidTest < ActiveSupport::TestCase
 
     expected = [
       "classDiagram",
-      "\tdirection RL",
+      "\tdirection TB",
       "\tclass `One`",
       "\tclass `Other`",
       "\t`One` -- `Other`"
@@ -273,7 +281,7 @@ class MermaidTest < ActiveSupport::TestCase
 
     expected = [
       "classDiagram",
-      "\tdirection RL",
+      "\tdirection TB",
       "\tclass `Emperor`",
       "\t`Emperor` -- `Emperor`"
     ]
@@ -289,7 +297,7 @@ class MermaidTest < ActiveSupport::TestCase
     result = diagram(:mermaid_style => :erdiagram).graph.uniq
 
     assert_equal "erDiagram", result[0]
-    assert_equal "\tdirection RL", result[1]
+    assert_equal "\tdirection TB", result[1]
     # Entity blocks are joined with newlines
     assert result.any? { |line| line.include?("Bar {") }
     assert result.any? { |line| line.include?("Beer {") }

--- a/test/unit/rake_task_test.rb
+++ b/test/unit/rake_task_test.rb
@@ -200,11 +200,11 @@ Error occurred while loading application: FooBar (RuntimeError)
 
   test "options task sets generator type" do
     Rake::Task["erd:options"].execute
-    assert_equal :graphviz, RailsERD.options.generator
-
-    ENV["generator"] = "mermaid"
-    Rake::Task["erd:options"].execute
     assert_equal :mermaid, RailsERD.options.generator
+
+    ENV["generator"] = "graphviz"
+    Rake::Task["erd:options"].execute
+    assert_equal :graphviz, RailsERD.options.generator
   end
 
   test "options task should set single parameter to only as array xxx" do


### PR DESCRIPTION
## Summary

This PR changes the default output format from Graphviz (PDF) to Mermaid (erDiagram style). Mermaid diagrams render natively in GitHub, GitLab, Notion, and many other documentation tools without requiring any external dependencies.

## Breaking Changes

- **Default generator**: `graphviz` → `mermaid`
- **Default filetype**: `pdf` → `mmd`
- **Default mermaid_style**: `classdiagram` → `erdiagram` (crow's foot notation with PK/FK markers)
- **Default direction**: `RL` → `TB` (top-down), now respects `orientation` option
- **ruby-graphviz gem**: Now optional (moved to development dependency)

## Migration Guide

**To continue using Graphviz output:**
1. Add `gem 'ruby-graphviz'` to your Gemfile
2. Run `bundle exec erd generator=graphviz filetype=pdf`

**To use classDiagram style instead of erDiagram:**
```bash
bundle exec erd mermaid_style=classdiagram
```

## Example Output

Running `bundle exec erd` now produces:

```mermaid
erDiagram
    direction TB
    User {
        integer id PK
        string name
        integer organization_id FK
    }
    Organization {
        integer id PK
        string name
    }
    Organization ||--o{ User : ""
```

## Changes

- Default generator changed from :graphviz to :mermaid
- Default mermaid_style changed from :classdiagram to :erdiagram
- Default filetype changed from :pdf to :mmd
- Mermaid direction now respects orientation option (horizontal=TB, vertical=LR)
- ruby-graphviz gem lazy-loaded only when generator=graphviz is specified
- Clear error messages when Graphviz is requested but gem not installed
- Updated README to reflect new defaults
- Updated tests