### PR TITLE
Release v2.0.0

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,30 @@
+2.0.0
+-----
+
+### Breaking Changes
+* Default generator changed from Graphviz to Mermaid (#448)
+* Default filetype changed from PDF to MMD (#448)
+* Default mermaid_style changed from classDiagram to erDiagram (#448)
+* Default direction changed from RL to TB (top-down) (#448)
+* ruby-graphviz gem is now optional (#448)
+
+### New Features
+* Mermaid erDiagram style with crow's foot notation and PK/FK markers (#445)
+* CLI now supports all options that rake task supports (#446, #447)
+* Mermaid direction respects orientation option (#448)
+
+### Bug Fixes
+* Fix --only flag with single model (#441)
+* Fix nil destination crash (#440)
+* Fix empty .erdconfig crash (#443)
+* Fix CLI string-to-symbol option conversion (#447)
+* Exclude Rails 8 Solid* internal models (#437, #438, #439)
+* Suppress Ruby 3.4 hash key warnings (#436)
+
+### Documentation
+* Updated README for Mermaid as default (#444, #448)
+* Added non-Rails usage example (#444)
+
 1.7.2
 -----
 * Suppress warnings for tableless Rails models (#390)

--- a/erd.mmd
+++ b/erd.mmd
@@ -1,7 +1,0 @@
-erDiagram
-	direction TB
-	Bar {
-	}
-	Beer {
-	}
-	Bar o|--}o Beer : ""

--- a/lib/rails_erd/version.rb
+++ b/lib/rails_erd/version.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
 module RailsERD
-  VERSION = "1.7.2"
+  VERSION = "2.0.0"
   BANNER  = "RailsERD #{VERSION}"
 end


### PR DESCRIPTION
## Release v2.0.0

This release makes Mermaid the default output format, removing the requirement for Graphviz installation.

### Breaking Changes
- Default generator changed from Graphviz to Mermaid
- Default filetype changed from PDF to MMD
- Default mermaid_style changed from classDiagram to erDiagram (crow's foot notation)
- Default direction changed from RL to TB (top-down)
- ruby-graphviz gem is now optional (add it to your Gemfile if you need PDF/PNG output)

### Migration Guide

**To continue using Graphviz output:**
```ruby
# Gemfile
gem 'ruby-graphviz'
```
```bash
bundle exec erd generator=graphviz filetype=pdf
```

**To use classDiagram style instead of erDiagram:**
```bash
bundle exec erd mermaid_style=classdiagram
```

### Full Changelog
See CHANGES.md for complete list of changes in this release.