### PR TITLE
Fix mermaid syntax errors for namespaced class names

### DIFF
--- a/lib/rails_erd/diagram/mermaid.rb
+++ b/lib/rails_erd/diagram/mermaid.rb
@@ -20,7 +20,8 @@ module RailsERD
       each_entity do |entity, attributes|
         if er_diagram?
           # Build entity block as a single string to avoid uniq issues with closing braces
-          entity_lines = ["\t#{entity} {"]
+          quoted_entity = quote_entity_name(entity)
+          entity_lines = ["\t#{quoted_entity} {"]
           attributes.each do |attr|
             key_marker = attribute_key_marker(attr)
             entity_lines << "\t\t#{attr.type} #{attr.name}#{key_marker}"
@@ -39,7 +40,7 @@ module RailsERD
         from, to = specialization.generalized, specialization.specialized
         if er_diagram?
           # erDiagram doesn't have a direct polymorphic notation, use inheritance-like
-          graph << "\t#{from.name} ||--o{ #{to.name} : \"specializes\""
+          graph << "\t#{quote_entity_name(from.name)} ||--o{ #{quote_entity_name(to.name)} : \"specializes\""
         else
           graph << "\t<<polymorphic>> `#{specialization.generalized}`"
           graph << "\t #{from.name} <|-- #{to.name}"
@@ -51,14 +52,14 @@ module RailsERD
         next unless from && to
 
         if er_diagram?
-          graph << "\t#{from.name} #{er_relation_notation(relationship)} #{to.name} : \"\""
+          graph << "\t#{quote_entity_name(from.name)} #{er_relation_notation(relationship)} #{quote_entity_name(to.name)} : \"\""
 
           from.children.each do |child|
-            graph << "\t#{child.name} #{er_relation_notation(relationship)} #{to.name} : \"\""
+            graph << "\t#{quote_entity_name(child.name)} #{er_relation_notation(relationship)} #{quote_entity_name(to.name)} : \"\""
           end
 
           to.children.each do |child|
-            graph << "\t#{from.name} #{er_relation_notation(relationship)} #{child.name} : \"\""
+            graph << "\t#{quote_entity_name(from.name)} #{er_relation_notation(relationship)} #{quote_entity_name(child.name)} : \"\""
           end
         else
           graph << "\t`#{from.name}` #{relation_arrow(relationship)} `#{to.name}`"
@@ -90,6 +91,17 @@ module RailsERD
 
       def er_diagram?
         options[:mermaid_style] == :erdiagram || options[:mermaid_style] == :er
+      end
+
+      # Quote entity names that contain special characters (like :: for namespaces)
+      # Mermaid erDiagram requires double quotes for names with special characters
+      def quote_entity_name(name)
+        name = name.to_s
+        if name.include?("::")
+          %("#{name}")
+        else
+          name
+        end
       end
 
       # erDiagram relationship notation using crow's foot

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -60,13 +60,16 @@ class ActiveSupport::TestCase
     superklass = args.first.kind_of?(Class) ? args.shift : ActiveRecord::Base
 
     names = full_name.split('::')
+    name = names.pop  # Remove and store the model name
 
-    parent_module = names[0..-1].inject(Object) do |parent,child|
-      parent = parent.const_set(child.to_sym, Module.new)
+    # Create namespace modules (all parts except the model name)
+    parent_module = names.inject(Object) do |parent, child|
+      if parent.const_defined?(child.to_sym, false)
+        parent.const_get(child.to_sym)
+      else
+        parent.const_set(child.to_sym, Module.new)
+      end
     end
-
-    parent_module ||= Object
-    name = names.last
 
     columns = args.first || {}
     klass = parent_module.const_set name.to_sym, Class.new(superklass)

--- a/test/unit/mermaid_test.rb
+++ b/test/unit/mermaid_test.rb
@@ -385,4 +385,63 @@ class MermaidTest < ActiveSupport::TestCase
 
     assert result.include?("erDiagram")
   end
+
+  # Namespace tests (Issue #450) ================================================
+
+  test "classDiagram should handle namespaced model names" do
+    create_model "Post"
+    create_module_model "Admin::Author", :post => :references do
+      belongs_to :post
+    end
+
+    result = diagram.graph
+
+    assert result.include?("classDiagram")
+    # Backticks should properly escape the namespace
+    assert result.any? { |line| line.include?("`Admin::Author`") }, "Should wrap namespaced entity in backticks"
+    assert result.any? { |line| line.include?("`Post`") && line.include?("`Admin::Author`") }, "Relationship should use backticks for both entities"
+  end
+
+  test "erDiagram should wrap namespaced model names in double quotes" do
+    create_model "Post"
+    create_module_model "Admin::Author", :post => :references do
+      belongs_to :post
+    end
+
+    result = diagram(:mermaid_style => :erdiagram).graph.join("\n")
+
+    assert result.include?("erDiagram")
+    # Double quotes are required for entity names containing ::
+    assert result.include?('"Admin::Author"'), "Should wrap namespaced entity in double quotes, got: #{result}"
+    # Relationship line should also quote the namespaced entity (order may vary)
+    assert result.match?(/("Admin::Author".*--.*Post|Post.*--.*"Admin::Author")/), "Relationship should quote namespaced entity"
+  end
+
+  test "erDiagram should handle multiple namespaced models in relationships" do
+    create_module_model "Admin::User" do
+      has_many :posts, class_name: "Blog::Post"
+    end
+    create_module_model "Blog::Post", :admin_user => :references do
+      belongs_to :admin_user, class_name: "Admin::User"
+    end
+
+    result = diagram(:mermaid_style => :erdiagram).graph.join("\n")
+
+    assert result.include?('"Admin::User"'), "Should quote Admin::User"
+    assert result.include?('"Blog::Post"'), "Should quote Blog::Post"
+  end
+
+  test "erDiagram should quote namespaced entities in specialization relationships" do
+    create_model "Vehicle", :type => :string
+    # Create a namespaced subclass (STI)
+    create_module_model "Transport::Car", Vehicle
+
+    # STI requires inheritance: true option
+    result = diagram(:mermaid_style => :erdiagram, :inheritance => true).graph.join("\n")
+
+    # The specialization relationship should quote the namespaced entity
+    assert result.include?('"Transport::Car"'), "Should quote namespaced specialized entity"
+    # Verify the specialization relationship line also quotes it
+    assert result.match?(/Vehicle.*--.*"Transport::Car"/), "Specialization relationship should quote namespaced entity"
+  end
 end


### PR DESCRIPTION
## Summary

Fixes #450 - Class names with namespace cause mermaid syntax errors

When Rails models use namespaces (e.g., `Admin::User`, `Api::V1::Resource`), the generated Mermaid `erDiagram` output was producing invalid syntax because entity names containing `::` were not quoted.

## Problem

Mermaid's erDiagram syntax requires entity names with special characters to be wrapped in double quotes. The previous output:

```mermaid
erDiagram
  Admin::User {
    integer id PK
  }
  Admin::User ||--o{ Post : ""
```

This causes syntax errors in Mermaid parsers.

## Solution

Added a `quote_entity_name` helper method that wraps entity names containing `::` in double quotes. The fix is applied to:

- Entity block definitions
- Relationship lines  
- Specialization (inheritance) relationships
- Child entity relationships

Now produces valid Mermaid syntax:

```mermaid
erDiagram
  "Admin::User" {
    integer id PK
  }
  "Admin::User" ||--o{ Post : ""
```

## Additional Fixes

- Fixed the `create_module_model` test helper which had a bug causing it to create `Admin::Author::Author` instead of `Admin::Author`

## Testing

- Added 4 new tests covering namespaced models in both `classDiagram` and `erDiagram` modes
- All 342 existing tests continue to pass