### PR TITLE
Clean up all generated erd files in rake task tests

### DIFF
--- a/test/unit/rake_task_test.rb
+++ b/test/unit/rake_task_test.rb
@@ -15,7 +15,7 @@ class RakeTaskTest < ActiveSupport::TestCase
   end
 
   def teardown
-    FileUtils.rm "erd.dot" rescue nil
+    FileUtils.rm Dir["erd*.*"] rescue nil
   end
 
   define_method :create_app do


### PR DESCRIPTION
## Summary

The `teardown` in `rake_task_test.rb` was only removing `erd.dot`, but since mermaid is now the default generator, some tests (specifically `test_generate_task_should_eager_load_application_environment`) were leaving behind `erd.mmd` files in the project root.

## Fix

Use the same glob pattern (`erd*.*`) that `mermaid_test.rb` and `graphviz_test.rb` already use to clean up all generated diagram files.

## Testing

```bash
# Before fix:
bundle exec rake test && ls erd*
# erd.mmd exists

# After fix:
bundle exec rake test && ls erd*
# No erd files left behind
```