### PR TITLE
Use temp directory for test output files

### DIFF
--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -2,6 +2,7 @@ require "rubygems"
 require "bundler/setup"
 require 'pry'
 require 'pry-nav'
+require 'tmpdir'
 
 require "active_record"
 
@@ -176,6 +177,9 @@ class ActiveSupport::TestCase
       File.expand_path("../../examples/erdconfig.not_exists", __FILE__)
 
     RailsERD.options = RailsERD.default_options.merge(Config.load)
+
+    # Use temp directory for test output to avoid polluting the project root
+    RailsERD.options.filename = File.join(Dir.tmpdir, "rails_erd_test_erd")
   end
 
   def name_to_object_symbol_pairs(name)

--- a/test/unit/graphviz_test.rb
+++ b/test/unit/graphviz_test.rb
@@ -7,10 +7,6 @@ class GraphvizTest < ActiveSupport::TestCase
     RailsERD.options.warn     = false
   end
 
-  def teardown
-    FileUtils.rm Dir["erd*.*"] rescue nil
-  end
-
   def diagram(options = {})
     @diagram ||= Diagram::Graphviz.new(Domain.generate(options), options).tap do |diagram|
       diagram.generate
@@ -52,11 +48,8 @@ class GraphvizTest < ActiveSupport::TestCase
   # Diagram properties =======================================================
   test "file name should depend on file type" do
     create_simple_domain
-    begin
-      assert_equal "erd.svg", Diagram::Graphviz.create(:filetype => :svg)
-    ensure
-      FileUtils.rm "erd.svg" rescue nil
-    end
+    result = Diagram::Graphviz.create(:filetype => :svg)
+    assert result.end_with?(".svg"), "Expected filename to end with .svg, got: #{result}"
   end
 
   test "rank direction should be tb for horizontal orientation" do

--- a/test/unit/mermaid_test.rb
+++ b/test/unit/mermaid_test.rb
@@ -8,10 +8,6 @@ class MermaidTest < ActiveSupport::TestCase
     RailsERD.options.mermaid_style = :classdiagram
   end
 
-  def teardown
-    FileUtils.rm Dir["erd*.*"] rescue nil
-  end
-
   def diagram(options = {})
     @diagram ||= Diagram::Mermaid.new(Domain.generate(options), options).tap do |diagram|
       diagram.generate
@@ -27,13 +23,10 @@ class MermaidTest < ActiveSupport::TestCase
   end
 
   # Diagram properties =======================================================
-  test "file name should be mmd" do
+  test "file name should have mmd extension" do
     create_simple_domain
-    begin
-      assert_equal "erd.mmd", Diagram::Mermaid.create
-    ensure
-      FileUtils.rm "erd.mmd" rescue nil
-    end
+    result = Diagram::Mermaid.create
+    assert result.end_with?(".mmd"), "Expected filename to end with .mmd, got: #{result}"
   end
 
   test "direction should be top to bottom by default" do

--- a/test/unit/rake_task_test.rb
+++ b/test/unit/rake_task_test.rb
@@ -14,10 +14,6 @@ class RakeTaskTest < ActiveSupport::TestCase
     Rake.application.options.silent = true
   end
 
-  def teardown
-    FileUtils.rm Dir["erd*.*"] rescue nil
-  end
-
   define_method :create_app do
     Object::Quux = Module.new
     Object::Quux::Application = Class.new


### PR DESCRIPTION
## Summary

Instead of generating diagram files in the project root during tests, use the system temp directory (`Dir.tmpdir`). This:

- Avoids polluting the project root with `erd.mmd`/`erd.dot` files
- Eliminates the need for manual cleanup in teardown methods
- Lets the OS handle temp file cleanup automatically

## Changes

- Set `RailsERD.options.filename` to temp directory path in `reset_config_file` (test setup)
- Remove now-unnecessary teardown cleanup methods from test files
- Update filename tests to check extension rather than full path

## Note

This supersedes #452 which added glob-based cleanup. With this change, no cleanup is needed at all since files go to the system temp directory.