### PR TITLE
Fix polymorphic exclude relationship crash

### DIFF
--- a/lib/rails_erd/domain.rb
+++ b/lib/rails_erd/domain.rb
@@ -210,11 +210,13 @@ module RailsERD
       excluded_names = [options.exclude].flatten.map(&:to_sym)
 
       # Suppress warning if either the source model or target model is excluded
-      excluded_names.include?(association.active_record.name.to_sym) ||
-        (association.klass.name && excluded_names.include?(association.klass.name.to_sym))
+      return true if excluded_names.include?(association.active_record.name.to_sym)
+
+      target_name = association.options[:polymorphic] ? association.class_name : association.klass.name
+      target_name && excluded_names.include?(target_name.to_sym)
     rescue NameError
-      # If we can't determine the target class, check only the source model
-      excluded_names.include?(association.active_record.name.to_sym)
+      # If we can't determine the target class, the source model was already checked above
+      false
     end
 
     def check_polymorphic_association_validity(association)

--- a/test/unit/domain_test.rb
+++ b/test/unit/domain_test.rb
@@ -255,6 +255,19 @@ class DomainTest < ActiveSupport::TestCase
     assert_match(/polymorphic interface FooBar does not exist/, output)
   end
 
+  test "relationships should not crash when exclude is present and a polymorphic association's interface does not exist" do
+    create_model "Foo" do
+      has_many :bars, :as => :foo
+    end
+    create_model "Bar", :foobar => :references do
+      belongs_to :foo_bar, :polymorphic => true
+    end
+    output = collect_stdout do
+      Domain.generate(:exclude => ["Qux"]).relationships
+    end
+    assert_match(/polymorphic interface FooBar does not exist/, output)
+  end
+
   test "relationships should not warn when a bad association is encountered if warnings are disabled" do
     create_model "Foo" do
       has_many :flabs


### PR DESCRIPTION
## Summary

Fixes a crash when generating relationships with `:exclude` present and a polymorphic association points at an interface class that does not exist.

## Root cause

`relationship_excluded?` checked `association.klass.name` before polymorphic association validity handling could report the missing polymorphic interface. For polymorphic associations, resolving `klass` can raise `NameError`, so the warning suppression path crashed or returned early instead of letting the normal polymorphic warning path run.

## Changes

- Check the source model exclusion before resolving the target class.
- Use `association.class_name` for polymorphic association target-name comparisons.
- Add a regression test for `Domain.generate(:exclude => ["Qux"]).relationships` with a missing polymorphic interface.


This fix closes #455 