### PR TITLE
Feature: Add `exclude_attributes` option to hide attributes per model

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,9 @@
+Unreleased
+----------
+
+### Features
+* Add `exclude_attributes` option to hide attributes on a per-model basis (#421)
+
 2.0.1
 -----
 

--- a/README.md
+++ b/README.md
@@ -97,7 +97,11 @@ From the command line, pass a comma separated list where each entry is either
 `Model` (hide all of its attributes) or `Model.attribute` (hide a single one):
 
 ```bash
-bundle exec erd exclude_attributes="BigTable,User.password_digest,User.remember_token"
+# rake task (bare key=value)
+bundle exec rake erd exclude_attributes="BigTable,User.password_digest,User.remember_token"
+
+# erd binary (flags require the -- prefix)
+bundle exec erd --exclude_attributes="BigTable,User.password_digest,User.remember_token"
 ```
 
 You can also customize fonts (useful if the defaults aren't available on your system):

--- a/README.md
+++ b/README.md
@@ -70,11 +70,34 @@ sort: true
 warn: true
 title: true
 exclude: null
+exclude_attributes: null
 only: null
 only_recursion_depth: null
 prepend_primary: false
 cluster: false
 splines: spline
+```
+
+### Hiding attributes for specific models
+
+While `attributes: false` hides attributes for *every* model, `exclude_attributes`
+lets you hide attributes for individual models without affecting the others. Map a
+model name to `true` to hide all of its attributes, or to a list of attribute names
+to hide only those:
+
+```yaml
+exclude_attributes:
+  BigTable: true            # hide all attributes for BigTable
+  User:                     # hide only these attributes for User
+    - password_digest
+    - remember_token
+```
+
+From the command line, pass a comma separated list where each entry is either
+`Model` (hide all of its attributes) or `Model.attribute` (hide a single one):
+
+```bash
+bundle exec erd exclude_attributes="BigTable,User.password_digest,User.remember_token"
 ```
 
 You can also customize fonts (useful if the defaults aren't available on your system):

--- a/lib/rails_erd.rb
+++ b/lib/rails_erd.rb
@@ -55,6 +55,7 @@ module RailsERD
         :warn, true,
         :title, true,
         :exclude, nil,
+        :exclude_attributes, nil,
         :only, nil,
         :only_recursion_depth, nil,
         :prepend_primary, false,

--- a/lib/rails_erd/cli.rb
+++ b/lib/rails_erd/cli.rb
@@ -72,6 +72,11 @@ Choice.options do
     desc "Filter to exclude listed models in diagram."
   end
 
+  option :exclude_attributes do
+    long "--exclude_attributes=MODEL[.ATTRIBUTE],..."
+    desc "Hide attributes per model. Use Model to hide all its attributes or Model.attribute to hide one, e.g. BigTable,User.password_digest."
+  end
+
   option :sort do
     long "--sort=BOOLEAN"
     desc "Sort attribute list alphabetically"

--- a/lib/rails_erd/config.rb
+++ b/lib/rails_erd/config.rb
@@ -73,6 +73,11 @@ module RailsERD
       when :only, :exclude
         Array(value).join(",").split(",").map { |v| v.strip }
 
+      # nil | { <string> => true | [<string>] }
+      when :exclude_attributes
+        require "rails_erd/diagram"
+        RailsERD::Diagram.normalize_exclude_attributes(value)
+
       # true | false
       when :disconnected, :indirect, :inheritance, :markup, :polymorphism,
            :warn, :cluster

--- a/lib/rails_erd/diagram.rb
+++ b/lib/rails_erd/diagram.rb
@@ -55,6 +55,14 @@ module RailsERD
   # attributes:: Selects which attributes to display. Can be any combination of
   #              +:content+, +:primary_keys+, +:foreign_keys+, +:timestamps+, or
   #              +:inheritance+.
+  # exclude_attributes:: Hides attributes on a per-model basis, without affecting
+  #                      other models. Accepts a hash that maps model names to
+  #                      either +true+ (hide all attributes for that model) or a
+  #                      list of attribute names to hide. From the command line it
+  #                      can also be given as a comma separated string where each
+  #                      entry is either +Model+ (hide all attributes) or
+  #                      +Model.attribute+ (hide a single attribute), for example
+  #                      <tt>exclude_attributes="BigTable,User.password_digest"</tt>.
   # disconnected:: Set to +false+ to exclude entities that are not connected to other
   #                entities. Defaults to +false+.
   # indirect:: Set to +false+ to exclude relationships that are indirect.
@@ -74,6 +82,38 @@ module RailsERD
       # the domain generation and the diagram generation.
       def create(options = {})
         new(Domain.generate(options), options).create
+      end
+
+      # Canonicalises the +exclude_attributes+ option into a hash that maps
+      # model names (as strings) to either +true+ (hide all attributes) or an
+      # array of attribute names to hide. Accepts several input shapes:
+      #
+      #   * a hash, e.g. <tt>{ "BigTable" => true, "User" => ["password_digest"] }</tt>
+      #     (values may be +true+/+"all"+ to hide every attribute, +false+/+nil+
+      #     to hide none, or a comma separated string / array of names);
+      #   * a string or array of <tt>Model</tt> / <tt>Model.attribute</tt>
+      #     entries, e.g. <tt>"BigTable,User.password_digest"</tt>.
+      def normalize_exclude_attributes(value)
+        return {} if value.nil? || value == false
+
+        if value.is_a?(Hash)
+          value.each_with_object({}) do |(model, attrs), result|
+            result[model.to_s] = normalize_exclude_attribute_value(attrs)
+          end
+        else
+          entries = Array(value).flat_map { |entry| entry.to_s.split(",") }
+          entries.each_with_object({}) do |entry, result|
+            model, attribute = entry.split(".", 2)
+            model = model.to_s.strip
+            next if model.empty?
+
+            if attribute.nil?
+              result[model] = true
+            elsif result[model] != true
+              (result[model] ||= []) << attribute.strip
+            end
+          end
+        end
       end
 
       protected
@@ -102,6 +142,16 @@ module RailsERD
 
       def callbacks
         @callbacks ||= Hash.new { proc {} }
+      end
+
+      def normalize_exclude_attribute_value(attrs)
+        case attrs
+        when true then true
+        when false, nil then []
+        when "all", :all, "true" then true
+        else
+          Array(attrs).flat_map { |attr| attr.to_s.split(",") }.map(&:strip).reject(&:empty?)
+        end
       end
     end
 
@@ -205,11 +255,29 @@ module RailsERD
     end
 
     def filtered_attributes(entity)
+      excluded = excluded_attributes_for(entity)
+      return [] if excluded == :all
+
       entity.attributes.reject { |attribute|
+        # Hide attributes excluded for this specific model.
+        excluded.include?(attribute.name) or
         # Select attributes that satisfy the conditions in the :attributes option.
         !options.attributes or entity.specialized? or
         [*options.attributes].none? { |type| attribute.send(:"#{type.to_s.chomp('s')}?") }
       }
+    end
+
+    # Returns the attribute exclusions configured for the given entity through
+    # the +exclude_attributes+ option. Returns +:all+ when every attribute
+    # should be hidden, or an array of attribute names otherwise.
+    def excluded_attributes_for(entity)
+      spec = normalized_exclude_attributes[entity.name]
+      return :all if spec == true
+      Array(spec)
+    end
+
+    def normalized_exclude_attributes
+      @normalized_exclude_attributes ||= self.class.normalize_exclude_attributes(options.exclude_attributes)
     end
 
     def warn(message)

--- a/test/unit/config_test.rb
+++ b/test/unit/config_test.rb
@@ -122,6 +122,17 @@ class ConfigTest < ActiveSupport::TestCase
     assert_equal [:content, :primary_keys], normalize_value(:attributes, ["content", "primary_keys"])
   end
 
+  test "normalize_value should canonicalize a hash when key is :exclude_attributes." do
+    value = { "BigTable" => true, "User" => ["password_digest"] }
+    expected = { "BigTable" => true, "User" => ["password_digest"] }
+    assert_equal expected, normalize_value(:exclude_attributes, value)
+  end
+
+  test "normalize_value should parse a string when key is :exclude_attributes." do
+    expected = { "BigTable" => true, "User" => ["password_digest"] }
+    assert_equal expected, normalize_value(:exclude_attributes, "BigTable,User.password_digest")
+  end
+
   test "normalize_value should return hash with symbol keys when key is :fonts and value is a hash." do
     fonts_value = { "normal" => "Arial", "bold" => "Arial Bold", "italic" => "Arial Italic" }
     expected = {:normal => "Arial", :bold => "Arial Bold", :italic => "Arial Italic"}

--- a/test/unit/diagram_test.rb
+++ b/test/unit/diagram_test.rb
@@ -358,4 +358,34 @@ class DiagramTest < ActiveSupport::TestCase
     Object.const_set :Whisky, Class.new(Beverage)
     assert_equal [], retrieve_attribute_lists(:inheritance => true)[Whisky].map(&:name)
   end
+
+  test "generate should hide all attributes for a model excluded with true" do
+    create_model "Book", :title => :string, :pages => :integer
+    create_model "Author", :name => :string
+    attribute_lists = retrieve_attribute_lists(:exclude_attributes => { "Book" => true })
+    assert_equal [], attribute_lists[Book].map(&:name)
+    assert_equal %w{name}, attribute_lists[Author].map(&:name)
+  end
+
+  test "generate should hide only listed attributes for a model" do
+    create_model "Book", :title => :string, :subtitle => :string, :pages => :integer
+    attribute_lists = retrieve_attribute_lists(:exclude_attributes => { "Book" => ["subtitle"] })
+    assert_equal %w{pages title}, attribute_lists[Book].map(&:name).sort
+  end
+
+  test "generate should hide attributes for the listed model only" do
+    create_model "Book", :title => :string
+    create_model "Author", :name => :string
+    attribute_lists = retrieve_attribute_lists(:exclude_attributes => { "Book" => ["title"] })
+    assert_equal [], attribute_lists[Book].map(&:name)
+    assert_equal %w{name}, attribute_lists[Author].map(&:name)
+  end
+
+  test "generate should accept exclude_attributes as a string" do
+    create_model "Book", :title => :string, :subtitle => :string
+    create_model "Author", :name => :string
+    attribute_lists = retrieve_attribute_lists(:exclude_attributes => "Book.subtitle,Author")
+    assert_equal %w{title}, attribute_lists[Book].map(&:name)
+    assert_equal [], attribute_lists[Author].map(&:name)
+  end
 end


### PR DESCRIPTION
## Summary

Closes #421.

Adds a new `exclude_attributes` option that hides attributes on a **per-model** basis without affecting other models. Until now attributes could only be hidden for *every* model at once (`attributes: false`), which is too coarse when a single large model is cluttering the diagram.

This is the proper built-in replacement for the `RailsERD::Diagram#filtered_attributes` monkey-patch that was being suggested as a workaround in the issue.

## Usage

Map a model name to `true` to hide all of its attributes, or to a list of attribute names to hide only those.

In `.erdconfig` (YAML):

```yaml
exclude_attributes:
  BigTable: true            # hide all attributes for BigTable
  User:                     # hide only these attributes for User
    - password_digest
    - remember_token
```

From the command line, pass a comma separated list where each entry is either `Model` (hide all of its attributes) or `Model.attribute` (hide a single one):

```bash
# rake task (bare key=value)
bundle exec rake erd exclude_attributes="BigTable,User.password_digest"

# erd binary (flags require the -- prefix)
bundle exec erd --exclude_attributes="BigTable,User.password_digest"
```

## Implementation

- **`lib/rails_erd.rb`** — register `exclude_attributes` (default `nil`) in `default_options`.
- **`lib/rails_erd/diagram.rb`** — apply per-model exclusions in `filtered_attributes`, and add a shared `normalize_exclude_attributes` class method that canonicalizes the various accepted input shapes (hash, comma-separated string, array) into `{ "Model" => true | [names] }`.
- **`lib/rails_erd/config.rb`** — normalize the option when loaded from `.erdconfig`.
- **`lib/rails_erd/cli.rb`** — add the `--exclude_attributes` CLI flag. (The rake task already handles any registered option generically, so no change was needed there.)
- **`README.md` / `CHANGES.md`** — document the new option.

## Accepted input shapes

The option is intentionally lenient so the same feature works naturally across YAML, the CLI, and rake:

| Input | Normalized to |
| --- | --- |
| `{ "BigTable" => true, "User" => ["password_digest"] }` | `{ "BigTable" => true, "User" => ["password_digest"] }` |
| `"BigTable,User.password_digest"` | `{ "BigTable" => true, "User" => ["password_digest"] }` |
| `["BigTable", "User.password_digest"]` | `{ "BigTable" => true, "User" => ["password_digest"] }` |
| `{ "User" => "all" }` | `{ "User" => true }` |

Namespaced models are supported (e.g. `Admin::User.password` splits on the first `.`).

## Tests

Added unit tests covering: hiding all attributes for a model, hiding only listed attributes, leaving other models untouched, the comma-separated string form, and config normalization. Full suite passes:

```
348 runs, 418 assertions, 0 failures, 0 errors, 2 skips
```
