### PR TITLE
Improvements: Follow-up to the `exclude_attributes` feature (#457).

### DIFF
--- a/lib/rails_erd/diagram.rb
+++ b/lib/rails_erd/diagram.rb
@@ -258,12 +258,14 @@ module RailsERD
       excluded = excluded_attributes_for(entity)
       return [] if excluded == :all
 
-      entity.attributes.reject { |attribute|
+      entity.attributes.select { |attribute|
         # Hide attributes excluded for this specific model.
-        excluded.include?(attribute.name) or
-        # Select attributes that satisfy the conditions in the :attributes option.
-        !options.attributes or entity.specialized? or
-        [*options.attributes].none? { |type| attribute.send(:"#{type.to_s.chomp('s')}?") }
+        next false if excluded.include?(attribute.name)
+        # Hide every attribute when the :attributes option is off or the entity
+        # is specialized (its attributes are shown on the parent instead).
+        next false if !options.attributes || entity.specialized?
+        # Otherwise keep only attributes matching the requested :attributes types.
+        [*options.attributes].any? { |type| attribute.send(:"#{type.to_s.chomp('s')}?") }
       }
     end
 

--- a/test/unit/diagram_test.rb
+++ b/test/unit/diagram_test.rb
@@ -388,4 +388,27 @@ class DiagramTest < ActiveSupport::TestCase
     assert_equal %w{title}, attribute_lists[Book].map(&:name)
     assert_equal [], attribute_lists[Author].map(&:name)
   end
+
+  test "normalize_exclude_attributes should split namespaced models on the first dot only" do
+    assert_equal({ "Admin::User" => ["password_digest"] },
+      Diagram.normalize_exclude_attributes("Admin::User.password_digest"))
+  end
+
+  test "normalize_exclude_attributes should treat a bare namespaced model as hide all" do
+    assert_equal({ "Admin::User" => true },
+      Diagram.normalize_exclude_attributes("Admin::User"))
+  end
+
+  test "normalize_exclude_attributes should return an empty hash for nil" do
+    assert_equal({}, Diagram.normalize_exclude_attributes(nil))
+  end
+
+  test "normalize_exclude_attributes should return an empty hash for false" do
+    assert_equal({}, Diagram.normalize_exclude_attributes(false))
+  end
+
+  test "normalize_exclude_attributes should ignore blank entries in a string" do
+    assert_equal({ "Book" => true },
+      Diagram.normalize_exclude_attributes("Book, ,"))
+  end
 end


### PR DESCRIPTION
## Summary

Follow-up to #457, addressing the two non-blocking suggestions from @kerrizor's review.

## 1. Restructure `filtered_attributes` for readability

The filter previously used a negated `reject` with an `or` chain, which was hard to parse. It's now a `select` with early `next` guards, so each hiding rule reads top-to-bottom:

```ruby
entity.attributes.select { |attribute|
  # Hide attributes excluded for this specific model.
  next false if excluded.include?(attribute.name)
  # Hide every attribute when the :attributes option is off or the entity
  # is specialized (its attributes are shown on the parent instead).
  next false if !options.attributes || entity.specialized?
  # Otherwise keep only attributes matching the requested :attributes types.
  [*options.attributes].any? { |type| attribute.send(:"#{type.to_s.chomp('s')}?") }
}
```

## 2. Add edge-case tests for `normalize_exclude_attributes`

Added direct unit tests for the cases called out in review:

- Namespaced models split on the first `.` only (`Admin::User.password_digest` → `{ "Admin::User" => ["password_digest"] }`)
- A bare namespaced model hides all of its attributes (`Admin::User` → `{ "Admin::User" => true }`)
- `nil` and `false` input normalize to `{}`
- Blank entries in a comma-separated string are ignored

These are tested at the normalization level (rather than full diagram generation) because the test `create_model` helper can't build namespaced constants — and the normalization method is where this logic lives.

## Tests

No behaviour change; the existing suite plus the new cases all pass.

```
354 runs, 425 assertions, 0 failures, 0 errors, 2 skips
```
