### PR TITLE
Fix README to show the correct command-line flag syntax for ERD gener…

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ This generates a Mermaid diagram (`erd.mmd`) by default. Mermaid diagrams render
 
 * Add `gem 'ruby-graphviz'` to your Gemfile
 
-* Run `bundle exec erd generator=graphviz filetype=pdf`
+* Run `bundle exec erd --generator=graphviz --filetype=pdf`
 
 ### Configuration
 
@@ -122,7 +122,7 @@ filename: docs/erd
 Or via command line:
 
 ```bash
-bundle exec erd filename="docs/erd"
+bundle exec erd --filename="docs/erd"
 ```
 
 Mermaid output (default)
@@ -133,7 +133,7 @@ Rails ERD generates [Mermaid](https://mermaid.js.org/) diagrams by default. Merm
 By default, Mermaid output uses `erDiagram` syntax with crow's foot notation, PK/FK markers, and proper cardinality. You can switch to `classDiagram` syntax if preferred:
 
 ```bash
-bundle exec erd mermaid_style=classdiagram
+bundle exec erd --mermaid_style=classdiagram
 ```
 
 Or in your `.erdconfig`:
@@ -164,7 +164,7 @@ Graphviz output
 For PDF, PNG, or SVG output, you can use the Graphviz generator:
 
 ```bash
-bundle exec erd generator=graphviz filetype=pdf
+bundle exec erd --generator=graphviz --filetype=pdf
 ```
 
 This requires:


### PR DESCRIPTION
## Summary

Several README examples invoked the `erd` binary with bare `key=value` arguments (e.g. `bundle exec erd filename="docs/erd"`). This PR fixes it as the `erd` binary does **not** accept this form — it parses options as `--`-prefixed long flags. The bare-key syntax only works for the **rake** task (`bundle exec rake erd ...`), which reads `key=value` pairs from `ENV`.

## Why the bare-key form doesn't work for the binary

The CLI defines its options through `Choice` using long flags, e.g.:

```ruby
option :filename do
  long "--filename=FILENAME"
  desc "Basename of the output diagram."
end
```

(`lib/rails_erd/cli.rb`)

Anything that isn't a recognized `--flag` is treated as the positional application path:

```ruby
path = Choice.rest.first || Dir.pwd
```

So `bundle exec erd filename="docs/erd"` is interpreted as "load the Rails app located at `filename=docs/erd`", and the filename option is never set.

The rake task, by contrast, intentionally reads bare `key=value` pairs from `ENV` (`lib/rails_erd/tasks.rake`), which is why `bundle exec rake erd filename="docs/erd"` does work.