### PR TITLE
Fix: Filter out specializations whose endpoint entity is not part of the domain

### DIFF
--- a/lib/rails_erd/diagram.rb
+++ b/lib/rails_erd/diagram.rb
@@ -250,7 +250,13 @@ module RailsERD
     def filtered_specializations
       @domain.specializations.reject { |specialization|
         !options.inheritance && specialization.inheritance? or
-        !options.polymorphism && specialization.polymorphic?
+        !options.polymorphism && specialization.polymorphic? or
+        # Drop specializations whose generalized or specialized entity is not
+        # part of the rendered domain (e.g. an abstract parent whose child model
+        # has no table). These resolve to a Null entity with a blank name and
+        # would otherwise produce an edge to a nameless entity (invalid output).
+        specialization.generalized.name.to_s.empty? or
+        specialization.specialized.name.to_s.empty?
       }
     end
 

--- a/test/unit/diagram_test.rb
+++ b/test/unit/diagram_test.rb
@@ -302,6 +302,21 @@ class DiagramTest < ActiveSupport::TestCase
       :polymorphism => true).map { |s| s.specialized.name }
   end
 
+  test "generate should not yield specializations whose entity is not part of the domain" do
+    # An abstract parent whose child model has no table (e.g. ActionMailbox::Record
+    # with a tableless ActionMailbox::InboundEmail): the child is excluded from the
+    # domain, so the specialization resolves to a nameless Null entity. It must not
+    # be yielded, otherwise generators emit an edge to a nameless entity (which is
+    # invalid Mermaid output).
+    Object.const_set "GhostRecord", Class.new(ActiveRecord::Base) { self.abstract_class = true }
+    Object.const_set "GhostThing", Class.new(GhostRecord)
+
+    specializations = retrieve_specializations(:inheritance => true, :polymorphism => true)
+    assert_equal [], specializations.select { |s|
+      s.generalized.name.to_s.empty? || s.specialized.name.to_s.empty?
+    }
+  end
+
   # Attribute filtering ======================================================
   test "generate should yield content attributes by default" do
     create_model "Book", :title => :string, :created_at => :datetime, :author => :references do


### PR DESCRIPTION
## Summary

Closes #459.

When `polymorphism` is enabled, Rails ERD can emit Mermaid `erDiagram` output that fails to parse, because specialization edges are rendered with a **blank entity** on one side:

```
"ActionMailbox::Record" ||--o{  : "specializes"
```

Mermaid rejects this with:

```
Error: Parse error on line 5:
...ox::Record" ||--o{  : "specializes"	"Ac
-----------------------^
Expecting 'UNICODE_TEXT', 'NUM', 'ENTITY_NAME', 'DECIMAL_NUM', 'ENTITY_ONE', 'NON_IDENTIFYING', 'IDENTIFYING', got 'COLON'
```

This PR makes the generated diagram valid by dropping specializations that point at an entity that isn't part of the rendered domain.

## Root cause

Rails-bundled engines define abstract base classes (`ActionMailbox::Record`, `ActionText::Record`, `ActiveStorage::Record`, `SolidQueue::Record`, etc.) whose concrete subclasses (e.g. `ActionMailbox::InboundEmail`) have **no table** in the application's database.

Those tableless subclasses are correctly dropped from the domain, but a `Specialization` is still created for the abstract parent. The specialized side resolves to a `NullSpecialization` whose `name` is `""`. When `polymorphism` is on, the generator then renders an edge to a nameless entity, producing an invalid Mermaid.

`Diagram#filtered_specializations` filters by `inheritance?`/`polymorphic?` but does not drop specializations whose endpoint entity is not part of the rendered domain.

## Fix

`Diagram#filtered_specializations` now also rejects any specialization whose generalized or specialized entity has a blank name (i.e. is absent from the rendered domain). This fixes both the Mermaid and Graphviz generators at the source.

```ruby
def filtered_specializations
  @domain.specializations.reject { |specialization|
    !options.inheritance && specialization.inheritance? or
    !options.polymorphism && specialization.polymorphic? or
    specialization.generalized.name.to_s.empty? or
    specialization.specialized.name.to_s.empty?
  }
end
```

## Testing

- Tested both Graphviz and Mermaid generators, and they are working as intended.
- Added a regression test in `test/unit/diagram_test.rb` that builds an abstract parent with a tableless child and asserts no blank-named specialization is yielded. It fails on `master` (yields a `NullSpecialization`) and passes with the fix.
- Full suite green: `355 runs, 426 assertions, 0 failures, 0 errors, 2 skips` (the 2 skips are pre-existing).