### PR TITLE
Docs: Add Unreleased changelog section for #458, #461, #463

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,13 @@
+Unreleased
+----------
+
+### Bug Fixes
+* Fix unparseable Mermaid output when `polymorphism` is enabled and an abstract parent has a tableless child (#459, #463)
+
+### Internal
+* Restructure `filtered_attributes` for readability and add edge-case tests for `exclude_attributes` normalization (#458)
+* Fix README to show the correct command-line flag syntax for ERD generator options (#461)
+
 2.0.2
 -----
 


### PR DESCRIPTION
## Summary

Three PRs merged **after** the `v2.0.2` tag but were never recorded in `CHANGES.md`. This adds an `Unreleased` section documenting them so the changelog reflects what's on `master` since the last release.

## Changes documented

### Bug Fixes
- **#463** (closes #459) — Fix unparseable Mermaid output when `polymorphism` is enabled and an abstract parent has a tableless child (e.g. `ActionMailbox::Record`). Previously rendered an edge to a nameless entity. Thanks @RSeven! 🐛

### Internal
- **#458** — Restructure `filtered_attributes` for readability and add edge-case tests for `exclude_attributes` normalization (follow-up to #457). Thanks @RSeven!
- **#461** — Fix README to show the correct command-line flag syntax for ERD generator options. Thanks @RSeven!

## Why `Unreleased` rather than a version number?

The next version isn't decided yet — that's a maintainer call at release time, and it depends on what else lands. This project also introduces version headers as part of the version-bump commit, so pre-creating a `2.0.x` header would diverge from that pattern. Using `Unreleased` (per [Keep a Changelog](https://keepachangelog.com)) lets us document merged work now and rename the section when the release is cut.

## Notes

- `lib/rails_erd/version.rb` is intentionally **unchanged** (`2.0.2`) — this is not a release.
- No code changes; documentation only.
