### PR TITLE
Docs: Update site for Mermaid-as-default (v2.0)

### DIFF
--- a/customise.html
+++ b/customise.html
@@ -25,6 +25,24 @@ Continue to read for an overview of all supported options.
 
 The following output options are available in Rails ERD.
 <dl>
+  <dt><pre>generator              mermaid | graphviz</pre></dt>
+  <dd>
+    Selects the diagram generator. The <tt>mermaid</tt> generator (the default)
+    produces text-based <a href="https://mermaid.js.org/">Mermaid</a> diagrams that
+    render natively on GitHub and GitLab, with no external dependencies. The
+    <tt>graphviz</tt> generator produces PDF/PNG/SVG output and requires the
+    <tt>ruby-graphviz</tt> gem and a Graphviz installation.
+    Default value: <tt>mermaid</tt>
+  </dd>
+
+  <dt><pre>mermaid_style          erdiagram | classdiagram</pre></dt>
+  <dd>
+    Only applies to the Mermaid generator. The <tt>erdiagram</tt> style (the
+    default) uses Mermaid's <tt>erDiagram</tt> syntax with crow's foot notation
+    and PK/FK markers. Set to <tt>classdiagram</tt> to use <tt>classDiagram</tt>
+    syntax instead. Default value: <tt>erdiagram</tt>
+  </dd>
+
   <dt><pre>attributes             &lt;type,...&gt; | false</pre></dt>
   <dd>
     Specifies which attributes to include in the diagram output. This can be any
@@ -50,25 +68,24 @@ The following output options are available in Rails ERD.
   <dt><pre>filename               &lt;string&gt;</pre></dt>
   <dd>
     The file basename of the generated diagram. Together with the file type, this
-    will determine the file name of the output. Default value: <tt>ERD</tt>
+    will determine the file name of the output. Default value: <tt>erd</tt>
   </dd>
 
-  <dt><pre>filetype               pdf | dot | ...</pre></dt>
+  <dt><pre>filetype               mmd | pdf | png | svg | dot | ...</pre></dt>
   <dd>
-    The file type of the generated diagram. PDF output is strongly recommended,
-    other formats may render significantly worse. The available formats depend
-    on your installation of Graphviz. If you set the file type to <tt>dot</tt>,
-    raw Graphviz instructions are saved in <tt>dot</tt> format. This does not
-    require Graphviz to be installed. Default value: <tt>pdf</tt>
+    The file type of the generated diagram. With the default Mermaid generator
+    this is <tt>mmd</tt> (a Mermaid text file). With the Graphviz generator, PDF
+    output is recommended; the available formats depend on your installation of
+    Graphviz. If you set the file type to <tt>dot</tt>, raw Graphviz instructions
+    are saved in <tt>dot</tt> format. Default value: <tt>mmd</tt>
   </dd>
 
   <dt><pre>indirect               true | false</pre></dt>
   <dd>
     Specifies whether or not to display relationships that are indirect.
     Indirect relationships are defined in Active Record by
-    <tt>has_many :through</tt> associations. Older versions of Graphviz may
-    have trouble drawing diagrams with indirect relationships.
-    Default value: <tt>false</tt>
+    <tt>has_many :through</tt> associations.
+    Default value: <tt>true</tt>
   </dd>
 
   <dt><pre>inheritance            true | false</pre></dt>
@@ -140,8 +157,41 @@ The following output options are available in Rails ERD.
   <dt><pre>exclude                &lt;string&gt;</pre></dt>
   <dd>
     Exclude specified models. Together with only, this will allow to filter out
-    models on your diagram. Default value: <tt>nil</tt>. Example:
-    <tt>exclude="User,Role"</tt>
+    models on your diagram. Models are matched by exact name.
+    Default value: <tt>nil</tt>. Example: <tt>exclude="User,Role"</tt>
+  </dd>
+
+  <dt><pre>only_recursion_depth   &lt;integer&gt;</pre></dt>
+  <dd>
+    When used with <tt>only</tt>, also includes models within this many
+    relationship "hops" of the listed models, instead of only the listed models
+    themselves. Useful for focusing a diagram on one part of a large domain.
+    Default value: <tt>nil</tt> (no recursion).
+  </dd>
+
+  <dt><pre>exclude_attributes     &lt;hash&gt; | &lt;string&gt;</pre></dt>
+  <dd>
+    Hides attributes on a <strong>per-model</strong> basis (unlike
+    <tt>attributes: false</tt>, which hides them for every model). Map a model
+    name to <tt>true</tt> to hide all of its attributes, or to a list of attribute
+    names to hide only those. From the command line, pass a comma separated list
+    where each entry is either <tt>Model</tt> (hide all) or <tt>Model.attribute</tt>
+    (hide one). Default value: <tt>nil</tt>. Example:
+    <tt>exclude_attributes="BigTable,User.password_digest"</tt>
+  </dd>
+
+  <dt><pre>prepend_primary        true | false</pre></dt>
+  <dd>
+    When enabled, lists the primary key attribute first within each entity,
+    instead of in alphabetical order with the other attributes.
+    Default value: <tt>false</tt>
+  </dd>
+
+  <dt><pre>cluster                true | false</pre></dt>
+  <dd>
+    <em>Graphviz generator only.</em> Groups models that share a namespace into
+    visual sub-clusters, which can make large, namespaced domains easier to read.
+    Default value: <tt>false</tt>
   </dd>
 
 </dl>

--- a/install.html
+++ b/install.html
@@ -4,40 +4,18 @@ layout: default
 title: Installation instructions
 ---
 <p>
-  Rails ERD generates diagrams using <a href="http://graphviz.org/">Graphviz</a>,
-  a visualisation library. Continue to read how to install Graphviz and Rails ERD,
-  so you can start creating model diagrams.
+  Since version 2.0, Rails ERD generates <a href="https://mermaid.js.org/">Mermaid</a>
+  diagrams by default. Mermaid is a text-based diagramming format that renders
+  natively on GitHub, GitLab, Notion, and many documentation tools &mdash; with
+  <strong>no external dependencies to install</strong>. Continue to read how to
+  install Rails ERD so you can start creating model diagrams.
 </p>
 
-
-<h2><a name="install-graphviz">Install Graphviz</a></h2>
-<p>
-  Rails ERD requires Graphviz. To install it, try one of the following...
-</p>
-
-{% highlight console cssclass=console %}
-% brew install graphviz           # Homebrew on Mac OS X
-{% endhighlight %}
-
-{% highlight console cssclass=console %}
-% sudo port install graphviz      # Macports on Mac OS X
-{% endhighlight %}
-
-{% highlight console cssclass=console %}
-% sudo aptitude install graphviz  # Debian and Ubuntu
-{% endhighlight %}
-
-<p>
-  <strong>Graphviz 2.22+ is recommended</strong>. Earlier versions may work,
-  but many bugs have been fixed since. If you have trouble with earlier versions,
-  you may wish to disable indirect relationships.
-  <a href="{{site.baseurl}}/customise.html#available-options">Learn more</a>.
-</p>
 
 <h2><a name="install-rails-erd">Install Rails ERD</a></h2>
 <p>
-  Rails ERD runs on all Rails 3+ platforms: Ruby 1.8/1.9, Rubinius, or JRuby
-  all work fine. Add Rails ERD as a plugin to your Ruby on Rails
+  Rails ERD requires <strong>Ruby 3.1+</strong> and <strong>Active Record 7.0+</strong>
+  (Rails 7.x and 8.x are supported). Add Rails ERD to your Ruby on Rails
   application. In your <tt>Gemfile</tt>...
 </p>
 
@@ -63,38 +41,66 @@ end
 {% endhighlight %}
 
 <p>
-  <strong>Done!</strong> Open <tt>ERD.pdf</tt> to view your diagram.
+  <strong>Done!</strong> This generates a Mermaid diagram in <tt>erd.mmd</tt> by
+  default, which you can paste into any Markdown file (it renders inline on GitHub
+  and GitLab) or view in a Mermaid renderer such as
+  <a href="https://mermaid.live/">mermaid.live</a>.
   Not completely satisfied? You can <a href="{{site.baseurl}}/customise.html">customise the output</a>.
 </p>
+
+<h2><a name="graphviz">Want PDF, PNG, or SVG output?</a></h2>
+<p>
+  The Mermaid generator has no external dependencies. If you'd rather produce
+  PDF, PNG, or SVG output, use the optional Graphviz generator. You'll need
+  <a href="http://graphviz.org/">Graphviz</a> 2.22+ installed&hellip;
+</p>
+
+{% highlight console cssclass=console %}
+% brew install graphviz           # Homebrew on macOS
+% sudo port install graphviz      # MacPorts on macOS
+% sudo apt-get install graphviz   # Debian and Ubuntu
+{% endhighlight %}
+
+<p>
+  &hellip;plus the <tt>ruby-graphviz</tt> gem in your <tt>Gemfile</tt>. Then
+  select the Graphviz generator when you generate the diagram...
+</p>
+
+{% highlight console cssclass=console %}
+% rake erd generator=graphviz filetype=pdf
+{% endhighlight %}
 
 
 <h2><a name="without-rails">Not using Rails?</a></h2>
 <p>
-  If you use Active Record 3+ outside of a Rails application, you can also use Rails
+  If you use Active Record outside of a Rails application, you can also use Rails
   ERD to create model diagrams for you. Install the <tt>rails-erd</tt> gem, load your
   models, and execute...
 </p>
 {% highlight ruby %}
 # Make sure all your models are loaded.
-require "rails_erd/diagram/graphviz"
+require "rails_erd/diagram/mermaid"
 
-RailsERD::Diagram::Graphviz.create
+RailsERD::Diagram::Mermaid.create
 {% endhighlight %}
 
 <h2><a name="trouble">Having trouble?</a></h2>
 <p>
   If Rails ERD doesn't work like you expected it to, don't give up immediately.
-  First of all, check if you can generate a graph without rendering it...
+  The default Mermaid output is plain text, so start by generating it and
+  inspecting the result...
 </p>
 {% highlight console cssclass=console %}
-% rake erd filetype=dot
+% rake erd
 {% endhighlight %}
 <p>
-  Check for a file named <tt>ERD.dot</tt>, and see if it's not empty. If everything
-  worked so far, Rails ERD is probably working fine. You can either tweak the
-  output before processing it with <tt>dot</tt> (the command line tool that
-  ships with Graphviz), or you can try with a very recent version of
-  <a href="http://graphviz.org/">Graphviz</a>, <strong>preferrably 2.26+</strong>.
+  Open the generated <tt>erd.mmd</tt> and check that it's not empty. If it looks
+  reasonable, Rails ERD is probably working fine, and any rendering problem is in
+  the tool displaying the Mermaid (try <a href="https://mermaid.live/">mermaid.live</a>).
+  If you're using the Graphviz generator instead and the output looks wrong, try
+  generating raw <tt>dot</tt> instructions with
+  <tt>rake erd generator=graphviz filetype=dot</tt> and inspecting <tt>erd.dot</tt>,
+  or upgrade to a recent version of <a href="http://graphviz.org/">Graphviz</a>.
 </p>
 <p>
   If things are still not running smoothly, I'd love to hear from you.


### PR DESCRIPTION
## Summary

The documentation site (`gh-pages`) predated the v2.0 release and still presented **Graphviz as a hard requirement**, with stale requirements (Rails 3 / Ruby 1.8) and an outdated options list. This brings `install.html` and `customise.html` in line with v2.0, where **Mermaid is the default generator with no external dependencies**.

> Targets the `gh-pages` branch (Jekyll site), not `master`.

## install.html

- Lead with Mermaid (no deps to install); move Graphviz to an optional "Want PDF/PNG/SVG?" section
- Fix requirements: **Ruby 3.1+ / Active Record 7.0+** (was "Rails 3+, Ruby 1.8/1.9")
- Default output is **`erd.mmd`**, not `ERD.pdf`; mention rendering on GitHub/GitLab/mermaid.live
- Non-Rails example uses `RailsERD::Diagram::Mermaid`
- Generator-aware troubleshooting section

## customise.html

- Document the new **`generator`** (mermaid | graphviz) and **`mermaid_style`** (erdiagram | classdiagram) options
- Fix defaults: `filetype` → **`mmd`**, `filename` → **`erd`**, `indirect` → **`true`**
- Add **`exclude_attributes`**, **`only_recursion_depth`**, **`prepend_primary`**, and **`cluster`** (Graphviz-only); note that `exclude` matches by exact name

## Notes

- Defaults verified against `lib/rails_erd.rb` `default_options`.
- The API / custom-output (yUML) sections were already generator-agnostic and left unchanged.
- Out of scope for this pass: `index.html` and `gallery.html` (minor wording only).
