### PR TITLE
Update LICENSE copyright year to 2026

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,4 +1,4 @@
-Copyright (c) 2010-2015 Voormedia B.V.
+Copyright (c) 2010-2026 Voormedia B.V.
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal


### PR DESCRIPTION
## Summary

`LICENSE.md` still showed `Copyright (c) 2010-2015`, while the README footer (`2010-2026`) and the docs site footer (auto-rendered current year) are already up to date. This brings the license year in line.

One-line change; no functional impact.