### PR TITLE
Fix stale LICENSE/CHANGES file references in YARD task and gemspec

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -9,7 +9,7 @@ Rake::TestTask.new do |test|
 end
 
 YARD::Rake::YardocTask.new do |yard|
-  yard.files = ["lib/**/*.rb", "-", "LICENSE", "CHANGES.md"]
+  yard.files = ["lib/**/*.rb", "-", "LICENSE.md", "CHANGES.md"]
 end
 
 desc "Generate diagrams for bundled examples"

--- a/rails-erd.gemspec
+++ b/rails-erd.gemspec
@@ -24,7 +24,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency "pry"
   s.add_development_dependency "pry-nav"
 
-  s.files         = `git ls-files -- {bin,lib,test}/* CHANGES.rdoc LICENSE Rakefile README.md`.split("\n")
+  s.files         = `git ls-files -- {bin,lib,test}/* CHANGES.md LICENSE.md Rakefile README.md`.split("\n")
   s.test_files    = `git ls-files -- test/*`.split("\n")
   s.executables   = `git ls-files -- bin/*`.split("\n").map{ |f| File.basename(f) }
   s.require_paths = ["lib"]


### PR DESCRIPTION
## Summary

The API docs on [rubydoc.info](https://rubydoc.info/github/voormedia/rails-erd/) are generated by **YARD** from `master`. The YARD task referenced a `LICENSE` file that doesn't exist (it's `LICENSE.md`), so:

```
[warn]: Could not find file: LICENSE
```

…and the license page was dropped from the generated docs. The gemspec had the same class of bug, referencing the non-existent `CHANGES.rdoc` and `LICENSE`, so **neither the changelog nor the license was being packaged into the published gem**.

## Fix

Point both at the actual filenames:

- **`Rakefile`** — `yard.files`: `LICENSE` → `LICENSE.md`
- **`rails-erd.gemspec`** — `s.files`: `CHANGES.rdoc` → `CHANGES.md`, `LICENSE` → `LICENSE.md`

## Verification

- `bundle exec rake yard` no longer emits the "Could not find file" warning; the License page now renders.
- `Gem::Specification.load("rails-erd.gemspec").files` now includes `LICENSE.md` and `CHANGES.md`.

After this merges to `master`, rubydoc.info will regenerate (or can be rebuilt manually from its page).

## Notes

Docs/packaging metadata only — no library code changes.
