### PR TITLE
Fix only/exclude leaking filtered-out models into Mermaid relationships

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -3,6 +3,7 @@ Unreleased
 
 ### Bug Fixes
 * Fix unparseable Mermaid output when `polymorphism` is enabled and an abstract parent has a tableless child (#459, #463)
+* Fix `only`/`exclude` not filtering relationships, so filtered-out models no longer leak back into Mermaid diagrams as phantom nodes (#472)
 
 ### Internal
 * Restructure `filtered_attributes` for readability and add edge-case tests for `exclude_attributes` normalization (#458)

--- a/lib/rails_erd/diagram.rb
+++ b/lib/rails_erd/diagram.rb
@@ -231,8 +231,7 @@ module RailsERD
 
     def filtered_entities
       @domain.entities.reject { |entity|
-        options.exclude.present? && [options.exclude].flatten.map(&:to_sym).include?(entity.name.to_sym) or
-        options[:only].present? && entity.model && ![options[:only]].flatten.map(&:to_sym).include?(entity.name.to_sym) or
+        excluded_by_filter?(entity) or
         !options.inheritance && entity.specialized? or
         !options.polymorphism && entity.generalized? or
         !options.disconnected && entity.disconnected?
@@ -243,8 +242,20 @@ module RailsERD
 
     def filtered_relationships
       @domain.relationships.reject { |relationship|
-        !options.indirect && relationship.indirect?
+        (!options.indirect && relationship.indirect?) ||
+          # Drop relationships to a model removed by :only/:exclude, otherwise the filtered-out
+          # model leaks back in: Graphviz skips such edges implicitly (it only draws an edge when
+          # both nodes exist) but Mermaid emits every relationship and renders any named entity.
+          excluded_by_filter?(relationship.source) ||
+          excluded_by_filter?(relationship.destination)
       }
+    end
+
+    # Whether the entity was removed from the diagram by the :only or :exclude option.
+    # Used to filter both entities and the relationships that touch them.
+    def excluded_by_filter?(entity)
+      (options.exclude.present? && [options.exclude].flatten.map(&:to_sym).include?(entity.name.to_sym)) ||
+        (options[:only].present? && entity.model && ![options[:only]].flatten.map(&:to_sym).include?(entity.name.to_sym))
     end
 
     def filtered_specializations

--- a/test/unit/diagram_test.rb
+++ b/test/unit/diagram_test.rb
@@ -165,6 +165,32 @@ class DiagramTest < ActiveSupport::TestCase
     assert_equal [Author, Editor], retrieve_entities(:only => ['Author', 'Editor']).map(&:model)
   end
 
+  test "generate should exclude relationships whose endpoints were removed by :only" do
+    create_model "Author"
+    create_model "Book", :author => :references do
+      belongs_to :author
+      has_many :reviews
+    end
+    create_model "Review", :book => :references do
+      belongs_to :book
+    end
+    relationships = retrieve_relationships(:only => [:Author, :Book])
+    assert_equal [Set[Author, Book]], relationships.map { |r| Set[r.source.model, r.destination.model] }
+  end
+
+  test "generate should exclude relationships to an excluded entity" do
+    create_model "Author"
+    create_model "Book", :author => :references do
+      belongs_to :author
+      has_many :reviews
+    end
+    create_model "Review", :book => :references do
+      belongs_to :book
+    end
+    relationships = retrieve_relationships(:exclude => [:Review])
+    assert_equal [Set[Author, Book]], relationships.map { |r| Set[r.source.model, r.destination.model] }
+  end
+
   test "generate should filter disconnected entities if disconnected is false" do
     create_model "Book", :author => :references do
       belongs_to :author


### PR DESCRIPTION
Fixes #472.

### Problem

`only`/`exclude` filter the entity list but not relationships. The Graphviz generator hides edges to filtered-out entities implicitly — `Graphviz#draw_edge` only adds an edge when both nodes exist (`node_exists?`). The Mermaid generator has no such guard: it emits every relationship, and Mermaid renders any entity named in a relationship. So with `--generator=mermaid --only="Author,Book"`, a `Book → Review` relationship still appears and `Review` is drawn as a phantom node.

### Fix

`Diagram#filtered_relationships` now also drops relationships whose source or destination was removed by `only`/`exclude`. The `only`/`exclude` check is extracted into a shared `excluded_by_filter?` predicate, reused by both `filtered_entities` and `filtered_relationships`, so the entity and relationship filters can't drift apart.

This fixes the leak at the shared layer for all generators. Graphviz output is unchanged (it already skipped these edges). Polymorphic-interface and STI rendering are untouched — the filter is scoped to `only`/`exclude`, not to entity visibility in general.

### Tests

Two regression tests in `diagram_test.rb` (generator-agnostic, via the existing `retrieve_relationships` helper) — one for `only`, one for `exclude`. Both fail on `master` and pass with this change. `diagram_test.rb` and `mermaid_test.rb` are green locally; the Graphviz suite needs the `dot` binary which I don't have locally, so I'm relying on CI for it.
