### PR TITLE
Make relationship order and direction deterministic across runs

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,6 +4,7 @@ Unreleased
 ### Bug Fixes
 * Fix unparseable Mermaid output when `polymorphism` is enabled and an abstract parent has a tableless child (#459, #463)
 * Fix `only`/`exclude` not filtering relationships, so filtered-out models no longer leak back into Mermaid diagrams as phantom nodes (#472)
+* Process models in a stable order so relationship order and source/destination direction are deterministic across runs, avoiding churn in generated diagrams committed to version control (#475)
 
 ### Internal
 * Restructure `filtered_attributes` for readability and add edge-case tests for `exclude_attributes` normalization (#458)

--- a/lib/rails_erd/domain.rb
+++ b/lib/rails_erd/domain.rb
@@ -128,6 +128,7 @@ module RailsERD
                     .reject { |model| tableless_rails_models.include?(model) }
                     .select { |model| check_model_validity(model) }
                     .reject { |model| check_habtm_model(model) }
+                    .sort_by { |model| model.name.to_s }
     end
 
     # Returns Rails model classes defined in the app

--- a/test/unit/diagram_test.rb
+++ b/test/unit/diagram_test.rb
@@ -261,7 +261,7 @@ class DiagramTest < ActiveSupport::TestCase
     create_model "Baz", :foo => :references do
       belongs_to :foo
     end
-    assert_equal [false, false, true], retrieve_relationships(:indirect => true).map(&:indirect?)
+    assert_equal({ false => 2, true => 1 }, retrieve_relationships(:indirect => true).map(&:indirect?).tally)
   end
 
   test "generate should filter indirect relationships if indirect is false" do

--- a/test/unit/domain_test.rb
+++ b/test/unit/domain_test.rb
@@ -151,6 +151,23 @@ class DomainTest < ActiveSupport::TestCase
     assert_equal ["Many", "More"], [relationship.source.name, relationship.destination.name]
   end
 
+  test "relationships should be deterministic regardless of model order" do
+    create_model "Author"
+    create_model "Book", :author => :references do
+      belongs_to :author
+      has_many :reviews
+    end
+    create_model "Review", :book => :references do
+      belongs_to :book
+    end
+    pairs = lambda do |models|
+      Domain.new(models).relationships.collect { |r| [r.source.name, r.destination.name] }
+    end
+    models = [Author, Book, Review]
+    # Order and source/destination direction must not depend on the input model order.
+    assert_equal pairs.call(models), pairs.call(models.reverse)
+  end
+
   # Specialization processing ================================================
   test "specializations should return empty array for empty domain" do
     assert_equal [], Domain.generate.specializations

--- a/test/unit/mermaid_test.rb
+++ b/test/unit/mermaid_test.rb
@@ -230,9 +230,9 @@ class MermaidTest < ActiveSupport::TestCase
       "\tclass `Bar`",
       "\tclass `Baz`",
       "\tclass `Foo`",
-      "\t`Foo` --> `Baz`",
       "\t`Foo` --> `Bar`",
-      "\t`Bar` ..> `Baz`"
+      "\t`Bar` ..> `Baz`",
+      "\t`Foo` --> `Baz`"
     ]
 
     assert_equal expected, diagram.graph.uniq


### PR DESCRIPTION
Fixes #475.

### Problem

The entity list is deterministic (`Entity.from_models` sorts), but relationships are not. `Domain#relationships` derives from `Domain#associations`:

```ruby
@associations ||= models.collect(&:reflect_on_all_associations).flatten.select { ... }
```

…and `models` is `ActiveRecord::Base.descendants`, whose order isn't stable across process boots (autoload/eager-load order). Because relationship grouping and source/destination assignment (`partition_associations`) depend on the order associations are encountered, both the **order** of relationships and their **direction** change run to run. For anyone committing generated diagrams (e.g. Mermaid `.mmd`) to version control, every regeneration produces a noisy, meaningless diff.

### Fix

Sort models by name in `Domain#models` so the whole relationship pipeline — order, grouping, and source/destination direction — is deterministic. This mirrors what `Entity.from_models` already does for entities, and is a one-line addition to the existing filter chain.

### Tests

- New regression test in `domain_test.rb`: builds a `Domain` from the same models in two orders and asserts the resulting relationships (source → destination pairs) are identical. It fails on `master` and passes with this change.
- Two existing tests hard-coded the old incidental relationship order; updated them: the indirect-relationships test now asserts an order-independent multiset (`tally`), and the Mermaid one-to-many test now expects the stable order.

`domain_test.rb`, `diagram_test.rb` and `mermaid_test.rb` pass locally; the Graphviz suite needs the `dot` binary I don't have locally, so I'm relying on CI for it.
