### PR TITLE
feat: Add Mermaid namespace clustering support

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,7 @@ Unreleased
 ----------
 
 ### New Features
+* Add `cluster: true` support for Mermaid `classDiagram` output, grouping entities by Ruby namespace into Mermaid `namespace { }` blocks (#479)
 * Add glob and regex pattern support for `exclude` and `only` options, allowing entire namespaces to be filtered with patterns like `"SolidQueue::*"` or `"/^Active/"` (#465)
 * Add tbls JSON generator for integration with Liam ERD and other tbls-compatible tools (#471, #474)
 

--- a/README.md
+++ b/README.md
@@ -236,6 +236,43 @@ exclude:
 - Only `i`, `m`, `x` regex flags are supported; other flags are ignored
 - When both `exclude` and `only` are specified, `only` is applied first, then `exclude`
 
+### Grouping models by namespace
+
+Use `cluster: true` to visually group models by their Ruby namespace. This is
+especially useful for large applications with many namespaced models.
+
+**With Graphviz output**, clustering creates subgraph boxes around each namespace:
+
+```bash
+bundle exec erd --generator=graphviz --cluster=true
+```
+
+**With Mermaid `classDiagram` output**, clustering uses Mermaid's native namespace blocks:
+
+```bash
+bundle exec erd --mermaid_style=classdiagram --cluster=true
+```
+
+This produces output like:
+
+```mermaid
+classDiagram
+    namespace Admin {
+        class User
+        class Role
+    }
+    namespace Billing {
+        class Invoice
+        class Payment
+    }
+    User --> Role
+    Invoice --> Payment
+```
+
+**Note:** Clustering is not supported with Mermaid's default `erDiagram` style
+(ER diagrams don't have a namespace concept). If you need clustering with Mermaid,
+use `mermaid_style: classdiagram`.
+
 You can also customize fonts (useful if the defaults aren't available on your system):
 
 ```yaml

--- a/lib/rails_erd/diagram/mermaid.rb
+++ b/lib/rails_erd/diagram/mermaid.rb
@@ -15,6 +15,16 @@ module RailsERD
         # Respect orientation option: horizontal = TB (top-down), vertical = LR (left-right)
         direction = (options.orientation.to_s == "vertical") ? "LR" : "TB"
         self.graph << "\tdirection #{direction}"
+
+        # Initialize namespace grouping for clustering
+        @entities_by_namespace = Hash.new { |h, k| h[k] = [] }
+        @clustering_enabled = options[:cluster] && !er_diagram?
+        @clustered_entities_emitted = false
+
+        # Warn if clustering requested with erDiagram (not supported)
+        if options[:cluster] && er_diagram? && options[:warn]
+          warn "Clustering is not supported with erDiagram style. Use mermaid_style: classdiagram instead."
+        end
       end
 
       each_entity do |entity, attributes|
@@ -28,6 +38,12 @@ module RailsERD
           end
           entity_lines << "\t}"
           graph << entity_lines.join("\n")
+        elsif @clustering_enabled
+          # Collect entities by namespace for later emission
+          ns = entity.namespace || ""
+          short_name = entity.namespace ? entity.name.split("::").last : entity.name
+          entity_block = build_class_diagram_entity(short_name, entity.name, attributes)
+          @entities_by_namespace[ns] << entity_block
         else
           graph << "\tclass `#{entity}`"
           attributes.each do |attr|
@@ -37,6 +53,12 @@ module RailsERD
       end
 
       each_specialization do |specialization|
+        # Emit clustered entities before the first specialization (same as relationships)
+        if @clustering_enabled && !@clustered_entities_emitted
+          emit_clustered_entities
+          @clustered_entities_emitted = true
+        end
+
         from, to = specialization.generalized, specialization.specialized
         if er_diagram?
           # erDiagram doesn't have a direct polymorphic notation, use inheritance-like
@@ -48,6 +70,12 @@ module RailsERD
       end
 
       each_relationship do |relationship|
+        # Emit clustered entities before the first relationship
+        if @clustering_enabled && !@clustered_entities_emitted
+          emit_clustered_entities
+          @clustered_entities_emitted = true
+        end
+
         from, to = relationship.source, relationship.destination
         next unless from && to
 
@@ -76,6 +104,12 @@ module RailsERD
 
       save do
         raise "Saving diagram failed!\nOutput directory '#{File.dirname(filename)}' does not exist." unless File.directory?(File.dirname(filename))
+
+        # Emit clustered entities if not already emitted (e.g., no relationships)
+        if @clustering_enabled && !@clustered_entities_emitted
+          emit_clustered_entities
+          @clustered_entities_emitted = true
+        end
 
         File.write(filename.gsub(/\s/,"_"), graph.uniq.join("\n"))
         filename
@@ -157,6 +191,36 @@ module RailsERD
 
       def arrow_tail(relationship)
         relationship.many_to? ? "<" : ""
+      end
+
+      # Build entity lines for classDiagram mode (used in clustering)
+      def build_class_diagram_entity(short_name, full_name, attributes)
+        lines = ["\t\tclass `#{short_name}`"]
+        attributes.each do |attr|
+          lines << "\t\t`#{short_name}` : +#{attr.type} #{attr.name}"
+        end
+        lines
+      end
+
+      # Emit entities grouped by namespace for clustering
+      def emit_clustered_entities
+        # Entities without namespace go first (outside any namespace block)
+        @entities_by_namespace[""].each do |entity_lines|
+          entity_lines.each { |line| graph << line.sub(/^\t\t/, "\t") }
+        end
+
+        # Then emit each namespace block
+        @entities_by_namespace.each do |ns, entity_blocks|
+          next if ns == ""
+
+          # Convert Ruby namespace (Admin::Users) to Mermaid format (Admin.Users)
+          mermaid_ns = ns.gsub("::", ".")
+          graph << "\tnamespace #{mermaid_ns} {"
+          entity_blocks.each do |entity_lines|
+            entity_lines.each { |line| graph << line }
+          end
+          graph << "\t}"
+        end
       end
 
     end

--- a/test/unit/mermaid_test.rb
+++ b/test/unit/mermaid_test.rb
@@ -504,13 +504,15 @@ class MermaidTest < ActiveSupport::TestCase
       belongs_to :post
     end
 
+    test_diagram = nil
+
     warning_output = collect_stdout do
-      RailsERD.options.warn = true
-      @diagram = nil  # Reset memoized diagram
-      diagram(:cluster => true, :mermaid_style => :erdiagram)
+      domain = Domain.generate
+      test_diagram = Diagram::Mermaid.new(domain, :cluster => true, :mermaid_style => :erdiagram, :warn => true)
+      test_diagram.generate
     end
 
-    result = diagram(:cluster => true, :mermaid_style => :erdiagram).graph.join("\n")
+    result = test_diagram.graph.join("\n")
 
     # Should emit warning about clustering not supported
     assert warning_output.include?("Clustering is not supported"), "Should warn about clustering not supported in erDiagram"

--- a/test/unit/mermaid_test.rb
+++ b/test/unit/mermaid_test.rb
@@ -437,4 +437,124 @@ class MermaidTest < ActiveSupport::TestCase
     # Verify the specialization relationship line also quotes it
     assert result.match?(/Vehicle.*--.*"Transport::Car"/), "Specialization relationship should quote namespaced entity"
   end
+
+  # Namespace clustering tests (Issue #479) =====================================
+
+  test "classDiagram with cluster should group entities by namespace" do
+    create_model "Post"
+    create_module_model "Admin::Author", :post => :references do
+      belongs_to :post
+    end
+    create_module_model "Admin::Role"
+
+    result = diagram(:cluster => true).graph.join("\n")
+
+    assert result.include?("classDiagram")
+    # Should have namespace block for Admin
+    assert result.include?("namespace Admin {"), "Should have namespace block for Admin"
+    # Author and Role should be inside the Admin namespace
+    assert result.match?(/namespace Admin \{[^}]*class `Author`/m), "Author should be inside Admin namespace"
+    assert result.match?(/namespace Admin \{[^}]*class `Role`/m), "Role should be inside Admin namespace"
+  end
+
+  test "classDiagram with cluster should place entities without namespace outside blocks" do
+    create_model "Post"
+    create_module_model "Admin::Author", :post => :references do
+      belongs_to :post
+    end
+
+    result = diagram(:cluster => true).graph.join("\n")
+
+    # Post should appear before any namespace block
+    post_index = result.index("class `Post`")
+    namespace_index = result.index("namespace Admin {")
+    assert post_index < namespace_index, "Entities without namespace should appear before namespace blocks"
+  end
+
+  test "classDiagram with cluster should handle nested namespaces" do
+    create_model "Post"
+    create_module_model "Admin::Users::Role", :post => :references do
+      belongs_to :post
+    end
+
+    result = diagram(:cluster => true).graph.join("\n")
+
+    # Nested namespace should use dot notation (Admin.Users)
+    assert result.include?("namespace Admin.Users {"), "Should convert :: to . in namespace names"
+    assert result.match?(/namespace Admin\.Users \{[^}]*class `Role`/m), "Role should be inside Admin.Users namespace"
+  end
+
+  test "classDiagram with cluster should render relationships outside namespace blocks" do
+    create_model "Post"
+    create_module_model "Admin::Author", :post => :references do
+      belongs_to :post
+    end
+
+    result = diagram(:cluster => true).graph.join("\n")
+
+    # Relationship should appear after the namespace block closes
+    namespace_close_index = result.index("}")
+    relationship_index = result.index("`Post` --> `Admin::Author`")
+    assert relationship_index > namespace_close_index, "Relationships should appear after namespace blocks"
+  end
+
+  test "erDiagram with cluster should emit warning and render flat" do
+    create_model "Post"
+    create_module_model "Admin::Author", :post => :references do
+      belongs_to :post
+    end
+
+    warning_output = collect_stdout do
+      RailsERD.options.warn = true
+      @diagram = nil  # Reset memoized diagram
+      diagram(:cluster => true, :mermaid_style => :erdiagram)
+    end
+
+    result = diagram(:cluster => true, :mermaid_style => :erdiagram).graph.join("\n")
+
+    # Should emit warning about clustering not supported
+    assert warning_output.include?("Clustering is not supported"), "Should warn about clustering not supported in erDiagram"
+    # Should still render the diagram (flat, no namespace blocks)
+    assert result.include?("erDiagram")
+    refute result.include?("namespace"), "erDiagram should not have namespace blocks"
+  end
+
+  test "classDiagram with cluster false should not group entities" do
+    create_model "Post"
+    create_module_model "Admin::Author", :post => :references do
+      belongs_to :post
+    end
+
+    result = diagram(:cluster => false).graph.join("\n")
+
+    assert result.include?("classDiagram")
+    # Should NOT have namespace blocks
+    refute result.include?("namespace"), "cluster: false should not create namespace blocks"
+    # Should use full entity names
+    assert result.include?("class `Admin::Author`"), "Should use full entity name without clustering"
+  end
+
+  test "classDiagram with cluster and inheritance should emit entities before specializations" do
+    create_model "Vehicle", :type => :string
+    create_module_model "Transport::Car", Vehicle
+
+    result = diagram(:cluster => true, :inheritance => true).graph.join("\n")
+
+    # Entity class definitions should appear BEFORE specialization lines
+    vehicle_class_index = result.index("class `Vehicle`")
+    polymorphic_index = result.index("<<polymorphic>>")
+    inheritance_index = result.index("<|--")
+
+    assert vehicle_class_index, "Should have Vehicle class definition.\nGot:\n#{result}"
+    assert polymorphic_index, "Should have polymorphic marker.\nGot:\n#{result}"
+    assert inheritance_index, "Should have inheritance relationship.\nGot:\n#{result}"
+
+    # The key assertion: class definitions must come BEFORE specializations
+    assert vehicle_class_index < polymorphic_index,
+      "Class definitions should appear before polymorphic markers.\n" \
+      "Got:\n#{result}"
+    assert vehicle_class_index < inheritance_index,
+      "Class definitions should appear before inheritance relationships.\n" \
+      "Got:\n#{result}"
+  end
 end


### PR DESCRIPTION
## Summary

Add `cluster: true` support for Mermaid `classDiagram` output, grouping entities by their Ruby namespace into Mermaid `namespace { }` blocks.

This brings Mermaid to parity with the existing Graphviz clustering feature.

Closes #479

## Motivation

When working with large schemas that include multiple namespaces (e.g., `Admin::`, `Billing::`, `SolidQueue::`), it's helpful to visually group related models together. The Graphviz generator already supports this via the `cluster` option, but Mermaid output ignored it.

## Changes

- Add namespace grouping logic to `lib/rails_erd/diagram/mermaid.rb`
- Entities grouped by namespace into Mermaid `namespace { }` blocks
- Nested namespaces converted to dot notation (`Admin::Users` → `Admin.Users`)
- Entities without namespace appear outside any namespace block
- Relationships render outside namespace blocks (Mermaid requirement)
- Warning emitted when `cluster: true` used with `erDiagram` (not supported)
- Add 7 new tests covering all clustering scenarios
- Document the `cluster` option in README.md

## Example Output

```yaml
# .erdconfig
mermaid_style: classdiagram
cluster: true
```

Produces:

```mermaid
classDiagram
    namespace Admin {
        class User
        class Role
    }
    namespace Billing {
        class Invoice
        class Payment
    }
    User --> Role
    Invoice --> Payment
```

## Limitations

Clustering is **not supported** with Mermaid's default `erDiagram` style (ER diagrams don't have a namespace concept). A warning is emitted if `cluster: true` is used with `erDiagram`.

## Testing

- 391 tests pass (0 failures)
- 7 new tests added for clustering scenarios
- Edge cases verified: nested namespaces, cross-namespace relationships, specializations