### PR TITLE
Remove ostruct dependency

### DIFF
--- a/.pryrc
+++ b/.pryrc
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+if defined?(PryByebug)
+  Pry.commands.alias_command 's', 'step'
+  Pry.commands.alias_command 'n', 'next'
+  Pry.commands.alias_command 'f', 'finish'
+  Pry.commands.alias_command 'c', 'continue'
+end

--- a/rails-erd.gemspec
+++ b/rails-erd.gemspec
@@ -16,13 +16,12 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency "activerecord", ">= 7.0"
   s.add_runtime_dependency "activesupport", ">= 7.0"
   s.add_runtime_dependency "choice", "~> 0.2.0"
-  s.add_runtime_dependency "ostruct" # Required as of Ruby 3.5 (no longer in stdlib)
 
   # ruby-graphviz is optional - only needed when using generator: graphviz
   # As of v2.0, the default generator is mermaid which has no external dependencies
   s.add_development_dependency "ruby-graphviz", "~> 1.2"
   s.add_development_dependency "pry"
-  s.add_development_dependency "pry-nav"
+  s.add_development_dependency "pry-byebug"
 
   s.files         = `git ls-files -- {bin,lib,test}/* CHANGES.md LICENSE.md Rakefile README.md`.split("\n")
   s.test_files    = `git ls-files -- test/*`.split("\n")

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -1,7 +1,7 @@
 require "rubygems"
 require "bundler/setup"
 require 'pry'
-require 'pry-nav'
+require 'pry-byebug'
 require 'tmpdir'
 
 require "active_record"


### PR DESCRIPTION
Changes:
- Prefer pry-byebug over pry-nav
   - pry-nav pins pry to versions containing ostruct (<0.15)
   - pry-nav also has not received updates in > 5 years.
-  Remove ostruct
   - This gem has no runtime dependency on ostruct, only via pry < 0.15.


### Context
Ostruct was recently added as a dependency but I don't think it needs to be. I raised a [comment on the original pr](https://github.com/voormedia/rails-erd/pull/435#issuecomment-4788117541) but did not receive a reply.
I don't actively work on this repository so please let me know if the pry-byebug substitution is reasonable. Let me know if you have any questions or require any changes.